### PR TITLE
Made @cic's keyDeviceIndex property public.

### DIFF
--- a/+neurostim/cic.m
+++ b/+neurostim/cic.m
@@ -49,13 +49,15 @@ classdef cic < neurostim.plugin
         paradigm@char           = 'test';
         clear@double            = 1;   % Clear backbuffer after each swap. double not logical
         
+        keyDeviceIndex          = []; % Use the first device by default
+                
         screen                  = struct('xpixels',[],'ypixels',[],'xorigin',0,'yorigin',0,...
             'width',[],'height',[],...
             'color',struct('text',[1 1 1],...
             'background',[1/3 1/3 5]),...
             'colorMode','xyL',...
             'frameRate',60,'number',[]);    %screen-related parameters.
-        
+           
         flipTime;   % storing the frame flip time.
         getFlipTime@logical = false; %flag to notify whether to get the frame flip time.
         requiredSlack = 0;  % required slack time in frame loop (stops all plugins after this time has passed)
@@ -98,7 +100,7 @@ classdef cic < neurostim.plugin
         %% Keyboard interaction
         allKeyStrokes          = []; % PTB numbers for each key that is handled.
         allKeyHelp             = {}; % Help info for key
-        keyDeviceIndex          = []; % Use the first device by default
+%         keyDeviceIndex          = []; % Use the first device by default
         keyHandlers             = {}; % Handles for the plugins that handle the keys.
         
         
@@ -875,7 +877,7 @@ classdef cic < neurostim.plugin
             notify(c,'BASEBEFOREEXPERIMENT');
             DrawFormattedText(c.window, 'Press any key to start...', c.center(1), 'center', WhiteIndex(c.window));
             Screen('Flip', c.window);
-            KbWait();
+            KbWait(c.keyDeviceIndex);
             c.flags.experiment = true;
             nrBlocks = numel(c.blocks);
             for blockNr=1:nrBlocks
@@ -891,7 +893,7 @@ classdef cic < neurostim.plugin
                 end
                 Screen('Flip',c.window);
                 if waitforkey
-                    KbWait([],2);
+                    KbWait(c.keyDeviceIndex,2);
                 end
                 c.blocks(c.block).trial=0;
                 while c.blocks(c.block).trial<c.blocks(c.block).nrTrials
@@ -1003,7 +1005,7 @@ classdef cic < neurostim.plugin
                 end
                 Screen('Flip',c.window);
                 if waitforkey
-                    KbWait([],2);
+                    KbWait(c.keyDeviceIndex,2);
                 end
             end %blocks
             c.trialStopTime = c.clockTime;
@@ -1012,7 +1014,7 @@ classdef cic < neurostim.plugin
             Screen('Flip', c.window);
             notify(c,'BASEAFTEREXPERIMENT');
             c.KbQueueStop;
-            KbWait;
+            KbWait(c.keyDeviceIndex);
             Screen('CloseAll');
             if c.PROFILE; report(c);end
         end

--- a/+neurostim/myRig.m
+++ b/+neurostim/myRig.m
@@ -20,6 +20,12 @@ end
 c.dirs.output = tempdir; % Output files will be stored here.
 
 switch computerName
+    case 'MU00101417X'
+      
+        % Shaun's MacBook Pro
+        c = rig(c,'eyelink',false,'mcc',false,'xpixels',2560,'ypixels',1600,'screenWidth',28.6,'frameRate',60,'screenNumber',max(Screen('screens')),'keyboardNumber',max(GetKeyboardIndices()));
+        smallWindow = true;
+        
     case 'MU00043185'
         
         %Office PC
@@ -97,6 +103,7 @@ pin.addParameter('ypixels',[]);
 pin.addParameter('screenWidth',[]);
 pin.addParameter('frameRate',[]);
 pin.addParameter('screenNumber',[]);
+pin.addParameter('keyboardNumber',[]);
 pin.addParameter('eyelink',[]);
 pin.addParameter('eyelinkCommands',[]);
 pin.addParameter('mcc',[]);
@@ -116,6 +123,9 @@ if ~isempty(pin.Results.screenWidth)
 end
 if ~isempty(pin.Results.screenNumber)
     c.screen.number  = pin.Results.screenNumber;
+end
+if ~isempty(pin.Results.keyboardNumber)
+    c.keyDeviceIndex  = pin.Results.keyboardNumber;
 end
 if pin.Results.eyelink
     neurostim.plugins.eyelink(c);


### PR DESCRIPTION
Making keyDeviceIndex public enables selecting between
multiple keyboards. This isn't an elegent solution but in the
short term makes neurostim useable on a laptop with external
keyboard connected.

The default behaviour (listen to the first keyboard) remains
unchanged.
