### PR TITLE
Modified handling of prms in cic.jitter().

### DIFF
--- a/+neurostim/cic.m
+++ b/+neurostim/cic.m
@@ -822,15 +822,15 @@ classdef cic < neurostim.plugin
                 bounds = c.jitterList(i).bounds;
                 sz = c.jitterList(i).size;
                 
+                if ~iscell(prms)
+                  prms = num2cell(prms);
+                end
+                
                 if isa(dist,'function_handle')
                     %User-defined function. Call it.
-                    c.(plg).(prop) = dist(prms);
+                    c.(plg).(prop) = dist(prms{:});
                 else
                     %Name of a standard distribution (i.e. known to Matlab's random,cdf,etc.)
-                    if ~iscell(prms)
-                        prms = num2cell(prms);
-                    end
-                    
                     if isempty(bounds)
                         %Sample from specified distribution (unbounded)
                         if ~iscell(sz)


### PR DESCRIPTION
The prms parameter is now _always_ forced to a cell array. This was
the case when using a named (i.e., known) distribution but not when
using a user-defined function. Now, user-defined functions may also
recieve multiple arguments in an intuitive manner, e.g.,

jitter(c,'plugin','property',{N,k},'distribution',@randperm);

rather than resorting to an anonymous function like this,

jitter(c,'plugin','property',{N,k},'distribution',@(x) randperm(x{:}))
