### PR TITLE
Small bug-fix to correct drawing of the diode square.

### DIFF
--- a/+neurostim/stimulus.m
+++ b/+neurostim/stimulus.m
@@ -15,7 +15,7 @@ classdef stimulus < neurostim.plugin
     %   rngSeed - seed of the RNG.
     %   diode.on,diode.color,diode.location,diode.size - a square box of
     %       specified color in the corner of the screen specified ('nw','sw', etc.),
-    %   for use with a photodiode recording.
+    %       for use with a photodiode recording.
     %   mccChannel - a linked MCC Channel to output alongside a stimulus.
     %
     %
@@ -345,16 +345,20 @@ classdef stimulus < neurostim.plugin
                 end
                 
                 %Pass control to the child class and any other listeners
-                beforeFrame(s);
-                
-                if s.diode.on
-                    Screen('FillRect',locWindow,+s.diode.color,+s.diodePosition);
-                end
+                beforeFrame(s);                
             elseif s.stimstart && (cFrame==sOffFrame)% if the stimulus will not be shown,
                 % get the next screen flip for stopTime
                 s.cic.getFlipTime=true;
             end
             Screen('glLoadIdentity', locWindow);
+            
+            % diode size/position is in pixels and we don't really want it
+            % changing even if we change the physical screen size (e.g., 
+            % when changing viewing distance) or being distorted by the
+            % transforms above...
+            if s.flags.on && s.diode.on
+              Screen('FillRect',locWindow,+s.diode.color,+s.diodePosition);
+            end
             
         end
         


### PR DESCRIPTION
The size and position of the diode square in stimulus.m are expressed in screen pixels (i.e., *not* physical screen units. I think that is correct since we don't really want them changing if/when we change the physical screen size (e.g., if changing viewing distance). We also don't want the diode square being distorted by any transformations in the stimulus object (scaling, rotation etc).

It seems to me that drawing the diode square therefore needs to be done *after* calling Screen('glLoadIdentity', ...) in baseBeforeFrame()... am I missing something here? I couldn't get the diode to work and this small fix restored what I think is/was the intended behaviour.
