### PR TITLE
Bug fix in neurostim.design affecting factorials with >2 factors.

### DIFF
--- a/+neurostim/design.m
+++ b/+neurostim/design.m
@@ -537,25 +537,28 @@ classdef design <handle & matlab.mixin.Copyable
                             error(['Some conditions do not fit in the [' num2str(lvls) '] factorial. Use a separate design for these conditions']);
                         end
                         %% Everything should match, lets assign
+
+                        % we know the number of factors and the number of
+                        % levels for each... initialize o.conditionSpecs if
+                        % it hasn't been initialized already
+                        if isempty(o.conditionSpecs)
+                          o.conditionSpecs = cell(o.nrLevels);
+                        end
+                        
                         for i=1:size(ix,1)
                             trgSub = neurostim.utils.vec2cell(ix(i,:));
-                            if numel(V)==1
+                            if numel(V) == 1
                                 srcSub = {1};
                             else
-                                srcSub  =trgSub;
+                                srcSub = trgSub;
                             end
                             thisV = V{srcSub{:}};
                             if isa(thisV,'neurostim.plugins.adaptive')
                                 thisV.belongsTo(o.name,o.lvl2cond(ix(i,:))); % Tell the adaptive to listen to this design/level combination
                             end
-                            if ndims(o.conditionSpecs)<numel(trgSub) || any(size(o.conditionSpecs)<[trgSub{:}]) || isempty(o.conditionSpecs(trgSub{:}))
-                                % new spec for this condition
-                                o.conditionSpecs{trgSub{:}} = {plg,prm,thisV};
-                            else
-                                % add to previous
-                                
-                                o.conditionSpecs{trgSub{:}} = cat(1,o.conditionSpecs{trgSub{:}},{plg,prm,thisV});
-                            end
+
+                            % add to previous
+                            o.conditionSpecs{trgSub{:}} = cat(1,o.conditionSpecs{trgSub{:}},{plg,prm,thisV});
                         end
                     else
                         %% Conditions-only design, specified one at a time


### PR DESCRIPTION
A bug in neurostim.design (in subsasgn()) caused multiple calls to
.conditions() to *always* overwrite the previous contents of .conditionSpecs
if the last factor in the factorial was a singleton. This was because
ndims(o.conditionSpecs) returned [N M] even if the factorial had three
factors, i.e., was actually N x M x 1. This was true for all factorial
designs with >2 factors where the last factor was a singleton.

The fix provided here initializes o.conditionSpecs to a cell array (of
appropriate dimensions to match the factorial) of empty matricies on the
first call to .conditions(), and concatenates the contents of
.conditionSpecs thereafter.