### PR TITLE
Bug fix in neurostim.design affecting factorials with >2 factors.

### DIFF
--- a/+neurostim/design.m
+++ b/+neurostim/design.m
@@ -557,8 +557,17 @@ classdef design <handle & matlab.mixin.Copyable
                                 thisV.belongsTo(o.name,o.lvl2cond(ix(i,:))); % Tell the adaptive to listen to this design/level combination
                             end
 
-                            % add to previous
-                            o.conditionSpecs{trgSub{:}} = cat(1,o.conditionSpecs{trgSub{:}},{plg,prm,thisV});
+                            % add to previous, or replace if it refers to the same property
+                            curSpecs = o.conditionSpecs{trgSub{:}};
+                            if ~isempty(curSpecs)
+                                %Check if we need to remove an existing value for this property
+                                isPlgMatch = cellfun(@(curSpecs) strcmp(curSpecs,plg),curSpecs(:,1));
+                                isPrmMatch = cellfun(@(curSpecs) strcmp(curSpecs,prm),curSpecs(:,2));
+                                curSpecs(isPlgMatch&isPrmMatch,:) = []; %Remove any matching line item
+                            end
+
+                            %Add this property to the list for this condition
+                            o.conditionSpecs{trgSub{:}} = cat(1,curSpecs,{plg,prm,thisV});
                         end
                     else
                         %% Conditions-only design, specified one at a time


### PR DESCRIPTION
A bug in neurostim.design (in subsasgn()) caused multiple calls to
.conditions() to *always* overwrite the previous contents of .conditionSpecs
if the last factor in the factorial was a singleton. This was because
ndims(o.conditionSpecs) returned [N M] even if the factorial had three
factors, i.e., was actually N x M x 1. This was true for all factorial
designs with >2 factors where the last factor was a singleton.

The fix provided here initializes o.conditionSpecs to a cell array (of
appropriate dimensions to match the factorial) of empty matricies on the
first call to .conditions(), and concatenates the contents of
.conditionSpecs thereafter.