### PR TITLE
Fixed a bug (?) in str2fun() due to partial matches of property names.

### DIFF
--- a/+neurostim/+utils/str2fun.m
+++ b/+neurostim/+utils/str2fun.m
@@ -21,7 +21,7 @@ function [f,h] = str2fun(str,c)
     % f1.startTime.fixating in ns functions. 
     % The code below translates this into the function call f1.startTime(''fixating'')
     plgAndProp = regexp(str,'(\<[a-zA-Z_]+\w*)\.([\w\.]+)','match');    
-    plgAndProp = unique(plgAndProp);
+    [plgAndProp,~,ix] = unique(plgAndProp);
     getLabel = cell(size(plgAndProp));
     h  = cell(size(plgAndProp));
     if ~isempty(plgAndProp)        
@@ -62,9 +62,9 @@ function [f,h] = str2fun(str,c)
             end
         end
         
-        %Replace each reference to them with args(i)
-        for i=1:numel(h)
-            str = regexprep(str, ['(\<' plgAndProp{i}, ')'],['args{',num2str(i),'}.' getLabel{i}]);
+        % Replace each reference to them with args{i}
+        for i=ix(:)'
+            str = regexprep(str, ['(\<' plgAndProp{i}, ')'],['args{',num2str(i),'}.' getLabel{i}],'once');
         end
     else
         h = {};


### PR DESCRIPTION
Consider a plugin with two properties: plg.prop, and plg.prop1. Attempting
to use plg.prop and plg.prop1 in a function string, something like:

  '@plg.prop + plg.prop1'

should be expanded as:

  '@args{1}.getValue() + args{2}.getValue()'

but is/was expanded as:

  '@args{1}.getValue() + args{1}.getValue()1'

due to regexprep replacing all instances of the first reference plg.prop,
including the partial match with plg.prop1.

The solution implemented here is to replace the references explicitly,
one at a time, left to right.