### PR TITLE
Added option to automatically go into eye tracker setup each block. M…

### DIFF
--- a/+neurostim/+plugins/eyelink.m
+++ b/+neurostim/+plugins/eyelink.m
@@ -74,10 +74,7 @@ classdef eyelink < neurostim.plugins.eyetracker
         boostEyeImage = 0;  % Factor by which to boost the eye image on a LUM calibrated display. [Default 0 means not boosted. Try values above 1.]         
         targetWindow;       % If an overlay is present, calibration targets can be drawn to it. This will be set automatically.
         
-        doTrackerSetup = true;  % Do it before the next trial
-        doDriftCorrect = false;  % Do it before the next trial
-    
-      
+ 
     end
         
     properties (Dependent)

--- a/+neurostim/+plugins/eyetracker.m
+++ b/+neurostim/+plugins/eyetracker.m
@@ -22,6 +22,10 @@ classdef eyetracker < neurostim.plugin
         keepExperimentSetup =true;
         eye='LEFT'; %LEFT,RIGHT, or BOTH
         tmr; %@timer
+        
+        doTrackerSetupEachBlock = false %Return to tracker setup before the first trial of every block.
+        doTrackerSetup = true;  % Do it before the next trial. Initialised to true to do setup on first trial.
+        doDriftCorrect = false;  % Do it before the next trial
     end
     
     properties
@@ -50,7 +54,12 @@ classdef eyetracker < neurostim.plugin
             o.tmr = timer('name','eyetracker.blink','startDelay',200/1000,'ExecutionMode','singleShot','TimerFcn',{@o.openEye});
         end
         
-        
+        function beforeBlock(o)
+            if o.doTrackerSetupEachBlock
+                %Return to tracker setup before the first trial of every block.
+                o.doTrackerSetup = true; %Will be done in next beforeTrial()
+            end
+        end
         
         function afterFrame(o)
             if o.useMouse
@@ -61,22 +70,22 @@ classdef eyetracker < neurostim.plugin
                 end
             end
         end
-        
-        
-         function keyboard(o,key)
+                
+        function keyboard(o,key)
             switch upper(key)
                 case 'W'
                     % Simulate a blink
-                    o.valid = false;                    
+                    o.valid = false;
                     if strcmpi(o.tmr.Running,'Off')
-                        start(o.tmr);                    
-                    end                   
+                        start(o.tmr);
+                    end
             end
-         end
-         function openEye(o,varargin)
-             o.valid = true;
-             writeToFeed(o,'Blink Ends')
-         end
+        end
+        
+        function openEye(o,varargin)
+            o.valid = true;
+            writeToFeed(o,'Blink Ends')
+        end
     end
     
 end


### PR DESCRIPTION
…oved some properties from eyelink.m into the parent eyetracker.m class. The rest of the changes are just auto-formatting.

This would cause a problem for any other child eye trackers if they also define those same properties, or have their own beforeBlock() function. @cnuahs, I think this might be true for your viewpoint class? I couldn't find it! let me know and I can fix anything that is needed. it would be tiny.