### PR TITLE
Added Intan plugin enabling estim

### DIFF
--- a/+neurostim/+plugins/intan.m
+++ b/+neurostim/+plugins/intan.m
@@ -1,0 +1,248 @@
+classdef intan < neurostim.plugins.ePhys
+    % Plugin for interfacing with the Intan GUI via tcp/ip
+    % Example usage:
+    % o = neurostim.plugins.intan(c,'intan',[RecDir].[SettingsFile]);
+    % Optional parameters may be specified via name-value pairs:
+    % RecDir - Directory used for saving Intan generated datafiles
+    % SettingsFile - .isf Intan settings file for a specific electrode
+    % configuration
+    
+    % Here's a list of commands Intan will recognise
+    % 'channel=A-001' % Initialises a new parameter set
+    % 'SET' % Commands Intan to program the headstage with new
+    % parameters
+    % ======= !!IMPORTANT!! ========
+    % Every call to 'SET' costs ~200 ms and necessitates a handshake
+    % between Intan and MATLAB to prevent desynchronisation
+    % Avoid excess 'SET' calls wherever possible
+    % 'HELLO' % Returns 'How are you?'
+    % 'RUOK' % Flushes the socket and returns 'YEAH'. Checks for
+    % TCP/IP response, maintains synchronisation between sockets
+    % 'RUN' % Starts the Intan GUI running - this will not save
+    % data
+    % 'RECORD' % Starts the Intan GUI running - this will save data
+    % to the given filepath
+    % 'STOP' % Stops the Intan GUI running
+    % 'OPENSTIM' % Opens the selected stim parameters dialog window. Used
+    % for setting amp settle options
+    % 'CLOSESTIM' % Closes the stim parameters dialog window
+    % 'RECOVER' % Returns 'PHEW'. Used for clearing the sockets on
+    % both ends of the connection.
+    % 'MCS' % Enables multi-channel stimulation. Be extremely
+    % careful with parameter sets.
+    % 'NOMCS' % Disables multi-channel stimulation. Default
+    % 'DALL' % Clears all stimulation parameters on all channels.
+    % 'CHANGEFRAME=1' % Changes the selected frame for OPENSTIM
+    % 'SETSAVEPATH' % Sets the filepath used for saving data
+    % 'LOADSETTINGS' % Loads an on-disk settings file
+    properties
+        estimulus = {};     % Contains a pointer to the active estim plugin
+        activechns = {};    % Contains a list of active stimulation channels
+        handshake = 0;      % Controls whether the Intan manager plugin will halt execution of the thread while awaiting
+                            % a handshake from the Intan firmware over the
+                            % TCP connection. !!Important!!
+    end
+    
+    methods (Access=public)
+        % Initialisation
+        function o = intan(c,name,varargin)
+            % Intan does not have any dependencies on the host computer
+            % Parse arguments
+            pin = inputParser;
+            pin.KeepUnmatched = true;
+            pin.addParameter('CreateNewDir', 1, @(x) assert(x == 0 || x == 1, 'It must be either 1 (true) or 0 (false).'));
+            pin.addParameter('RecDir', '', @ischar); % Save path on the Intan computer            
+            pin.addParameter('SettingsFile', '', @ischar); % Settings file for Intan
+            pin.addParameter('tcpSocket', '');
+            pin.addParameter('testMode', 0, @isnumeric); % Test mode that disables stimulation and recording
+            pin.addParameter('mapPath', '', @ischar);
+            pin.addParameter('chnMap', [], @isnumeric);
+            pin.addParameter('mcs', 0, @isnumeric); % Controls multi-channel stimulation in Intan's firmware
+            pin.parse(varargin{:});
+            args = pin.Results;
+            % Call parent class constructor
+            % Pass HostAddr to the parent constructor via the 'Unmatched'
+            % property of the input parser
+            o = o@neurostim.plugins.ePhys(c,name,pin.Unmatched);            
+
+            % Initialise class properties
+            o.addProperty('createNewDir',args.CreateNewDir,'validate',@isnumeric);
+            o.addProperty('recDir',args.RecDir,'validate',@ischar);
+            o.addProperty('settingsFile',args.SettingsFile,'validate',@ischar);
+            o.addProperty('tcpSocket',args.tcpSocket);
+            o.addProperty('testMode',args.testMode);
+            o.addProperty('mapPath',args.mapPath);
+            o.addProperty('chnMap',args.chnMap);
+            o.addProperty('mcs',args.mcs);
+        end
+        % Communcation
+        function sendMessage(o,msg)
+            % Send a message to Intan
+            if ~iscell(msg)
+                msg = {msg};
+            end
+            for ii = 1:numel(msg)
+                fprintf(o.tcpSocket,msg{ii});
+            end
+            if o.handshake
+                OK = 0;
+                while(~OK)
+                    OK = o.checkTCPOK;
+                end
+                o.handshake = 0; % Disable handshake
+            end
+        end
+        function beforeExperiment(o)     
+            % Create a tcp/ip socket           
+            o.tcpSocket = o.local_TCPIP_server;
+            o.chnMap = o.loadIntanChannelMap;
+            o.sendMessage('RUOK');
+            if o.mcs
+                o.sendMessage('MCS');
+            else
+                o.sendMessage('NOMCS');
+            end
+            o.sendMessage(['SETSAVEPATH=' o.cic.estim.recDir]);
+            o.startRecording();            
+        end
+        function beforeTrial(o)
+            if ~isempty(o.activechns) && o.mcs
+                marker = ones(1,numel(o.activechns));
+                for ii = 1:numel(o.estimulus)
+                    thisChn = getIntanChannel(o,ii);                    
+                    for jj = 1:numel(o.activechns)
+                        if strcmp(o.activechns{jj},thisChn)
+                            marker(jj) = 0;
+                        end
+                    end
+                end
+                kk = find(marker == 1,1,'last');
+                for jj = 1:numel(o.activechns)
+                    if marker(jj) % Disable all channels not used in the coming trial
+                        msg{1} = strcat('channel=',o.activechns{jj});
+                        msg{2} = 'enabled=0';
+                        msg{3} = 'SET'; % This will execute a 'SET' command, which necessitates a handshake to maintain synchronisation between Intan and MATLAB
+                        if jj == kk
+                            o.handshake = 1;
+                        end
+                        o.sendMessage(msg);
+                    end
+                end
+                o.activechns = {};
+            end
+            o.setupIntan();
+        end
+        function afterTrial(o)
+            o.estimulus = {};
+        end
+        function afterExperiment(o)
+            o.stopRecording();
+        end
+        function setupIntan(o)
+            % Convert the parameter set into strings
+            % Convert the channel number into an Intan channel identifier
+            for ii = 1:numel(o.estimulus)
+                thisChn = getIntanChannel(o,ii);
+                msg{1} = strcat('channel=',thisChn);
+                msg{2} = strcat('pulseOrTrain=',num2str(o.estimulus{ii}.pot));
+                if o.estimulus{ii}.pot
+                    if o.estimulus{ii}.nod == 1
+                        msg{3} = strcat('numberOfStimPulses=',num2str(o.estimulus{ii}.nsp));
+                    elseif o.estimulus{ii}.nod == 2
+                        nsp = floor((o.estimulus{ii}.pod / 1e6) * o.estimulus{ii}.fre);
+                        if nsp > 99
+                            nsp = 99;
+                        end
+                        msg{3} = strcat('numberOfStimPulses=',num2str(nsp));
+                    end
+                end
+                msg{4} = strcat('pulseTrainPeriod=',num2str((1e6/o.estimulus{ii}.fre)));
+                msg{5} = strcat('refractoryPeriod=',num2str(o.estimulus{ii}.ptr));
+                msg{6} = strcat('firstPhaseDuration=',num2str(o.estimulus{ii}.fpd));
+                msg{7} = strcat('secondPhaseDuration=',num2str(o.estimulus{ii}.spd));
+                msg{8} = strcat('interphaseDelay=',num2str(o.estimulus{ii}.ipi));
+                msg{9} = strcat('firstPhaseAmplitude=',num2str(o.estimulus{ii}.fpa));
+                msg{10} = strcat('secondPhaseAmplitude=',num2str(o.estimulus{ii}.spa));
+                msg{11} = strcat('preStimAmpSettle=',num2str(o.estimulus{ii}.prAS));
+                msg{12} = strcat('postStimAmpSettle=',num2str(o.estimulus{ii}.poAS));
+                msg{13} = strcat('postStimChargeRecovOn=',num2str(o.estimulus{ii}.prCR));
+                msg{14} = strcat('postStimChargeRecovOff=',num2str(o.estimulus{ii}.poCR));
+                msg{15} = strcat('stimShape=',num2str(o.estimulus{ii}.stSH));
+                msg{16} = strcat('enableAmpSettle=',num2str(o.estimulus{ii}.enAS));
+                msg{17} = strcat('maintainAmpSettle=',num2str(o.estimulus{ii}.maAS));
+                msg{18} = strcat('enableChargeRecovery=',num2str(o.estimulus{ii}.enCR));
+                msg{19} = strcat('ID=',num2str(o.cic.trial));
+                msg{20} = strcat('enabled=',num2str(o.estimulus{ii}.enabled));
+                msg{21} = 'SET';
+                if ii == numel(o.estimulus) && o.mcs
+                    o.handshake = 1; % This will execute a 'SET' command, which necessitates a handshake to maintain synchronisation between Intan and MATLAB
+                end
+                o.sendMessage(msg);
+                o.activechns(numel(o.activechns)+1) = {thisChn};
+            end
+        end
+        function c = getIntanChannel(o,ii)            
+            c = [o.estimulus{ii}.port '-' num2str(o.chnMap(o.estimulus{ii}.chn)-1,'%03d')];
+        end
+        function chnMap = loadIntanChannelMap(o)
+            if exist(o.mapPath,'file')
+                chnMap = load(o.mapPath,'chnMap'); chnMap = chnMap.chnMap;
+            else
+                [mapFile,mapPath] = uigetfile('*.mat','Select the Intan Channel Map File');
+                o.mapPath = [mapPath mapFile];
+                chnMap = load(o.mapPath,'chnMap'); chnMap = chnMap.chnMap;
+            end
+        end
+        function OK = checkTCPOK(o)
+            % Initialise the check
+            flushinput(o.tcpSocket);
+            fprintf(o.tcpSocket,'RUOK');
+            data = fscanf(o.tcpSocket);
+            data = string(data(1:end-1));
+            if ~strcmp(data,"YEAH")
+                OK = 0;
+            else
+                OK = 1;
+            end
+            flushinput(o.tcpSocket);
+        end
+    end
+    methods (Access = protected)
+        function startRecording(o)
+            if ~o.testMode
+                o.sendMessage('RECORD');
+            end
+        end
+        function stopRecording(o)
+            if ~o.testMode
+                o.sendMessage('STOP');
+            end
+        end        
+    end
+    methods (Static)
+        function t = local_TCPIP_server
+            CONNECTION = '0.0.0.0'; % Use '0.0.0.0' to allow any connection, from anywhere
+            PORT = 9004;            % Can be anything, but must be consistent. Don't use a common port.
+            TYPE = 'server';        % Use 'client' to connect to the other side of this connection.
+            TIMEOUT = 1;            % How long execution will wait for a response (seconds)
+            myIP = neurostim.plugins.intan.getIP;            
+            disp(['The IP address is: ' myIP]);
+            disp(['The port is: ' num2str(PORT)]);
+            t = tcpip(CONNECTION,PORT,'NetworkRole',TYPE,'Timeout',TIMEOUT);
+            fopen(t);
+            data = fscanf(t);
+            data = string(data(1:end-1));
+            if ~strcmp(data,"READY")
+                disp('ERROR. BAD CONNECTION.')
+            end
+            flushinput(t)
+        end
+        function myIP = getIP
+            [~,myIP]=system('ipconfig');
+            myIP = strsplit(myIP,'IPv4 Address');
+            myIP = splitlines(myIP{2});
+            myIP = strsplit(myIP{1},':');
+            myIP = myIP{2}(2:end);
+        end        
+    end
+end

--- a/+neurostim/+stimuli/estim.m
+++ b/+neurostim/+stimuli/estim.m
@@ -1,0 +1,78 @@
+classdef estim < neurostim.stimulus
+    % Base class for electrical stimuli in PTB.    
+    % Adjustable variables:
+    %   dph - duration of each phase of the stimulus waveform (eg. 200 us)
+    %   ipi - inter-phase interval (eg. 100 us)   
+    %   nsp - the number of stimulation pulses
+    %   fre - the frequency of stimulation pulses
+    %   chn - the channel stimulation is delivered on
+    %   on - time the stimulus should come 'on' (ms) from start of trial
+    %   duration - time the stimulus should turn 'off' (ms) from start of trial
+    %   enabled - turn stimulation on or off
+    %   fpa - first phase amplitude of stimulus waveform (eg. 10 uA)
+    %   spa - second phase amplitude of stimulus waveform (eg. 10 uA)
+    %   fpd - duration of first phase of the stimulus waveform (eg. 200 us)
+    %   spd - duration of second phase of the stimulus waveform (eg. 200 us)    
+    %   pot - controls single-pulse or multi-pulse stimulation trains
+    %   nod - controls number of stimulation pulses in train, or duration
+    %   pod - duration of stimulation pulses (us). Max 99 pulses
+    %   ptr - post-stimulation pulse train refractory period
+    %   prAS - pre-stimulation amp settle ON time
+    %   poAS - post-stimulation amp settle OFF time
+    %   prCR - post-stimulation charge recovery ON time
+    %   poCR - post-stimulation charge recovery OFF time
+    %   stSH - stimulation shape (eg. biphasic, triphasic, cathodic-first. See Intan for codes)
+    %   enAS - controls amp settle enabled
+    %   maAS - maintain or end amp settle throughout stimulation pulse train
+    %   enCR - controls charge recovery enabled
+    %   recDir - specify the recording directory for Intan
+    %   settingsFile - specify an Intan general settings file
+    %   port - controls which port Intan uses for stimulation ('A','B','C','D')
+    
+    properties
+        bit = 1; % This is the mcc digital line bit, allowing control over which pin will carry this stimulus' on and off functions
+    end
+    
+    methods (Access = public)
+        function s = estim(c,name)
+            s = s@neurostim.stimulus(c,name);            
+            %% user-settable properties
+            s.addProperty('enabled',0,'validate',@isnumeric);
+            s.addProperty('fpa',0,'validate',@isnumeric);
+            s.addProperty('spa',0,'validate',@isnumeric);
+            s.addProperty('fpd',0,'validate',@isnumeric);
+            s.addProperty('spd',0,'validate',@isnumeric);
+            s.addProperty('ipi',0,'validate',@isnumeric);
+            s.addProperty('pot',0,'validate',@isnumeric);
+            s.addProperty('nod',1,'validate',@isnumeric);
+            s.addProperty('nsp',0,'validate',@isnumeric);
+            s.addProperty('fre',0,'validate',@isnumeric);
+            s.addProperty('pod',0,'validate',@isnumeric);
+            s.addProperty('ptr',1e3,'validate',@isnumeric);
+            s.addProperty('chn','A-001','validate',@ischar);
+            s.addProperty('prAS',200,'validate',@isnumeric);
+            s.addProperty('poAS',160000,'validate',@isnumeric);
+            s.addProperty('prCR',100000,'validate',@isnumeric);
+            s.addProperty('poCR',150000,'validate',@isnumeric);
+            s.addProperty('stSH',1,'validate',@isnumeric);
+            s.addProperty('enAS',1,'validate',@isnumeric);
+            s.addProperty('maAS',1,'validate',@isnumeric);
+            s.addProperty('enCR',1,'validate',@isnumeric);
+            s.addProperty('recDir','','validate',@ischar);
+            s.addProperty('port','A','validate',@ischar);
+        end
+        function beforeExperiment(s)
+            s.onsetFunction = @(s,t) s.cic.mcc.digitalOut(8+s.bit,true);
+            s.offsetFunction = @(s,t) s.cic.mcc.digitalOut(8+s.bit,false);
+        end
+        function beforeTrial(s)
+            if s.enabled
+                setActive(s);
+            end
+        end
+        function setActive(s)
+            % This function sets the current estim parameters to active in the Intan plugin
+            s.cic.intan.estimulus(numel(s.cic.intan.estimulus)+1) = {s};
+        end
+    end    
+end %classdef

--- a/demos/saccadeIntanDemo.m
+++ b/demos/saccadeIntanDemo.m
@@ -1,0 +1,160 @@
+function saccadeIntanDemo(varargin)
+% Show how to implement a simple task where the subject has to fixate one
+% point and then saccade to a second. Implements an Intan plugin to allow
+% electrical stimulation
+%
+%   This demo shows how to use:
+%       - Behavioral control
+%       - Electrical stimulation
+%
+%   The task:
+%
+%       (1) "Fixate" on the fixation point to start the trial by clicking on it with the mouse
+%       (2) Fixate the new target once it appears.
+%
+%   *********** Press "Esc" twice to exit a running experiment ************
+
+p = inputParser;
+p.KeepUnmatched = true;
+p.addParameter('bit',1,@(x) validateattributes(x,{'numeric'},{'nonempty','scalar','>=',1,'<=',8}));
+
+p.parse(varargin{:});
+
+import neurostim.*
+commandwindow;
+
+%% ========= Specify rig configuration  =========
+
+%Create a Command and Intelligence Centre object (the central controller for everything). Here a cic is returned with some default settings for this computer, if it is recognized.
+c = myRig;
+c.addPropsToInform('saccade.stateName'); % Show this value on the command prompt after each trial (i.e. whether the answer was correct and whether fixation was successful).
+
+%Make sure there is an eye tracker (or at least a virtual one)
+if isempty(c.pluginsByClass('eyetracker'))
+    e = neurostim.plugins.eyetracker(c);      %Eye tracker plugin not yet added, so use the virtual one. Mouse is used to control gaze position (click)
+    e.useMouse = true;
+end
+
+%% ============== Add stimuli ==================
+
+%Fixation dot
+f=stimuli.fixation(c,'fix');    %Add a fixation stimulus object (named "fix") to the cic. It is born with default values for all parameters.
+f.shape = 'CIRC';               %The seemingly local variable "f" is actually a handle to the stimulus in CIC, so can alter the internal stimulus by modifying "f".               
+f.size = 0.25;
+f.color = [1 0 0];
+f.on=0;                         %What time should the stimulus come on? (all times are in ms)
+f.duration = 3000;              %How long should it be displayed?
+
+t = duplicate(f,'target');      % make a duplicate, called target.
+t.X = NaN;                      % Will be varied in the factorial design, below.
+t.on = '@fix.on + fix.duration';  % Use a function to turn on when target turns off
+
+%% ========== Add Intan plugin ================
+% Add the Intan plugin
+i = neurostim.plugins.intan(c,'intan');
+i.testMode = 0; % Disable stimulation and recording while testing
+i.mapPath = 'C:\Users\localadmin\Documents\git\EPhysLabSoftware\Experimental Design\Constants\NN-Mapping-ISeries.mat';
+i.mcs = 1;      % Enable (1) or disable (0) stimulation on multiple channels simultaneously
+
+%% ========== Add electrical stimuli ==========
+p = stimuli.estim(c,'estim');
+p.recDir = 'C:\Users\localadmin\Desktop\Data\BehaviourTest\estim_pen1';
+p.on = '@target.on';            % Stimulation ON time relative to start of trial (ms)
+p.duration = 1000;              % Stimulation duration relative to ON time (ms)
+p.enabled = NaN;                % Enables (1) or disables (0) stimulation
+p.chn = NaN;                    % Stimulation channel(s)                    % Will be varied below
+p.fpa = NaN;                    % Stimulation first phase amplitude (uA)    % Will be varied below
+p.spa = NaN;                    % Stimulation second phase amplitude (uA)   % Will be varied below
+p.fpd = 200;                    % Stimulation first phase duration (us)
+p.spd = 200;                    % Stimulation second phase duration (us)
+p.ipi = 100;                    % Inter-phase interval (us)
+p.pot = 1;                      % Single pulse (0) or train (1) % Will override any other pulse train parameters
+p.nod = 1;                      % Specify number of stimulation pulses (1) or total duration of pulse train (2)
+p.nsp = 10;                     % Number of stimulation pulses % Max 99
+p.pod = 200000;                 % Duration of stimulation pulses (us) % Max 99 pulses
+p.fre = 200;                    % Frequency of stimulation (Hz)
+p.ptr = 1e6;                    % Post-pulse-train refractory period
+p.prAS = 200;                   % Pre-stimulus amp settle START (us, relative to stimulation)
+p.poAS = 160000;                % Post-stimulus amp settle END (us, relative to stimulation)
+p.prCR = 100000;                % Post-stimulus charge recovery START (us, relative to stimulation)
+p.poCR = 150000;                % Post-stimulus charge recovery END (us, relative to stimulation)
+p.stSH = 1;                     % Stimulus pulse shape. 1 = biphasic charge balanced
+p.enAS = 1;                     % Enable (1) or disable (0) amp settle
+p.maAS = 1;                     % Maintain (1) or end (0) amp settle throughout stimulus pulse trains
+p.enCR = 1;                     % Enable (1) or disable (0) charge recovery
+p.port = 'A';                   % The port Intan uses to communicate to the headstage. Only used by Intan
+
+%% ========== Add a second estimulus plugin ==========
+p2 = stimuli.estim(c,'estim2');
+p2.recDir = 'C:\Users\localadmin\Desktop\Data\BehaviourTest\estim_pen1';
+p2.on = '@fix.on';               % Stimulation ON time relative to start of trial (ms)
+p2.duration = 1000;              % Stimulation duration relative to ON time (ms)
+p2.enabled = NaN;                % Enables (1) or disables (0) stimulation
+p2.chn = NaN;                    % Stimulation channel(s)                    % Will be varied below
+p2.fpa = NaN;                    % Stimulation first phase amplitude (uA)    % Will be varied below
+p2.spa = NaN;                    % Stimulation second phase amplitude (uA)   % Will be varied below
+p2.fpd = 200;                    % Stimulation first phase duration (us)
+p2.spd = 200;                    % Stimulation second phase duration (us)
+p2.ipi = 100;                    % Inter-phase interval (us)
+p2.pot = 1;                      % Single pulse (0) or train (1) % Will override any other pulse train parameters
+p2.nod = 1;                      % Specify number of stimulation pulses (1) or total duration of pulse train (2)
+p2.nsp = 10;                     % Number of stimulation pulses % Max 99
+p2.pod = 200000;                 % Duration of stimulation pulses (us) % Max 99 pulses
+p2.fre = 200;                    % Frequency of stimulation (Hz)
+p2.ptr = 1e6;                    % Post-pulse-train refractory period
+p2.prAS = 200;                   % Pre-stimulus amp settle START (us, relative to stimulation)
+p2.poAS = 160000;                % Post-stimulus amp settle END (us, relative to stimulation)
+p2.prCR = 100000;                % Post-stimulus charge recovery START (us, relative to stimulation)
+p2.poCR = 150000;                % Post-stimulus charge recovery END (us, relative to stimulation)
+p2.stSH = 1;                     % Stimulus pulse shape. 1 = biphasic charge balanced
+p2.enAS = 1;                     % Enable (1) or disable (0) amp settle
+p2.maAS = 1;                     % Maintain (1) or end (0) amp settle throughout stimulus pulse trains
+p2.enCR = 1;                     % Enable (1) or disable (0) charge recovery
+p2.port = 'A';                   % The port Intan uses to communicate to the headstage. Only used by Intan
+
+%% ========== Add required behaviours =========
+g = behaviors.saccade(c,'saccade');
+g.X = '@fix.X';
+g.Y = '@fix.Y';
+g.from = 2000;       % If fixation has not started at this time, move to the next trial
+g.to = '@fix.stopTime'; 
+g.saccadeDuration = 2000;
+g.targetDuration = 1000;
+g.targetX = '@target.X';
+g.targetY = '@target.Y';
+g.tolerance = 3;
+g.failEndsTrial = true;
+g.successEndsTrial  = true;
+
+%% ========== Specify feedback/rewards ========= 
+% Play a correct/incorrect sound for the 2AFC task
+plugins.sound(c);           %Use the sound plugin
+
+% Add correct/incorrect feedback
+s= plugins.soundFeedback(c,'soundFeedback');
+s.add('waveform','correct.wav','when','afterTrial','criterion','@saccade.isSuccess');
+s.add('waveform','incorrect.wav','when','afterTrial','criterion','@saccade.isSuccess');
+
+%% ========== Add a MCC DAQ to control the digital line ===========
+plugins.mcc(c);
+
+%% Experimental design
+c.trialDuration = inf;                        % Trials are infinite, but the saccade behavior ends the trial on success or fail.
+
+%Specify experimental conditions
+myDesign=design('dummy');                      %Type "help neurostim/design" for more options.
+myDesign.fac1.target.X = [-15,-15,-15,5,5,-10,-10,-10];
+myDesign.fac1.estim.enabled = [1,1,1,0,0,1,1,1];
+myDesign.fac1.estim.chn = [1,1,1,1,1,1,1,1];
+myDesign.fac1.estim.fpa = [1,3,5,-1,-1,1,3,5];
+myDesign.fac1.estim.spa = [1,3,5,-1,-1,1,3,5];
+myDesign.fac1.estim2.enabled = [0,0,0,0,0,1,1,1];
+myDesign.fac1.estim2.chn = [2,2,2,2,2,2,2,2];
+myDesign.fac1.estim2.fpa = [1,3,5,-1,-1,1,3,5];
+myDesign.fac1.estim2.spa = [1,3,5,-1,-1,1,3,5];
+myBlock=block('myBlock',myDesign);             %Create a block of trials using the factorial. Type "help neurostim/block" for more options.
+myBlock.nrRepeats=1;
+%% Make sure the plugins are in the right order
+c.order(['eye'],['saccade'],['sound'],['soundFeedback'],['mcc'],['fix'],['target'],['estim'],['estim2'],['intan']); %#ok<NBRAK>
+%% Run it
+c.run(myBlock);    


### PR DESCRIPTION
Added intan.m, a manager plugin handling communication between neurostim and the modified Intan recording/stimulation software
Added estim.m, a stimulus plugin containing a parameter set for electrical stimulation experiments, designed to work with the Intan manager
Added saccadeIntanDemo.m, a demo script detailing how both intan.m and estim.m are used