### PR TITLE
Inactivated prm validation

### DIFF
--- a/+neurostim/parameter.m
+++ b/+neurostim/parameter.m
@@ -259,9 +259,15 @@ classdef parameter < handle & matlab.mixin.Copyable
             end
             
             % validate
-            if ~isempty(o.validate)
-                o.validate(v);
-            end
+            % AM: commented out because no action was being taken on validation fail
+            % anyway. Perhaps it was deemed too costly?
+            %
+            %TODO: restore validation.
+            
+%             if ~isempty(o.validate)
+%                 o.validate(v);
+%             end
+            
             % Log the new value
             storeInLog(o,v,t);
         end


### PR DESCRIPTION
Hi @bartkrekelberg.

Happy new year!

Parameters were being validated but no action taken on fail.  Commented out for now. Fixing is easy enough but could cause lots of failures in existing paradigms (that have been silently failing). What do you think is the best way forward?

If we activate the validation, there is another problem: you can't currently set c.iti = plugins.jitter(...). Validation of iti param fails because isnan() doesn't accept jitter objects. isnumeric() is also part of that validation anon function and works but returns false (so an example of a silent fail).
