### PR TITLE
Fixed a bug in RSVP stimuli and a rounding issue in stimulus duration

### DIFF
--- a/+neurostim/plugin.m
+++ b/+neurostim/plugin.m
@@ -564,7 +564,7 @@ classdef plugin  < dynamicprops & matlab.mixin.Copyable & matlab.mixin.Heterogen
         end
     end
     
-    methods (Access={?neuorstim.plugin,?neurostim.parameter})
+    methods (Access={?neuorstim.plugin,?neurostim.parameter,?neurostim.stimulus})
         
         %Accessing neurostim.parameters is much slower than accessing a raw
         %member variable. Because we define many such parms (with addProperty) in the base


### PR DESCRIPTION
Fixes a bug in which localized parameters in an RSVP would update in the second frame and not hte first of an rsvp item. (This requires the call to localizeParms(s,true)).


Fixes a bug/oddity with duration:

Previously the offFrame was determined by rounding  on+duration to the nearest frame.  But the onFrame was determined by rounding on alone.
In the current code, on is rounded first, and then duration is rounded separately, and the offFrame calculation is done by adding onFrame+durationFrame
This has the advantage that a duration less than half a frame will always round to zero and this no longer depends on the on-time
Example: on =1, duration =0.4
round(1) = 1, round(1 + 0.4) = 1
no stimulus shown, because onFrame =1, offFrame =1

But if on= 1.4
round(1.4)= 1, and round (1.4+0.4) = 2
one stimulus frame shown in frame 1