### PR TITLE
This change allows plugins to be added after calling c.run  

### DIFF
--- a/+neurostim/cic.m
+++ b/+neurostim/cic.m
@@ -653,9 +653,7 @@ classdef cic < neurostim.plugin
             c.flags.experiment =false;
         end
         
-        function o = add(c,o)
-            assert(~c.used,'CIC objects are single-use only. Please create a new one to start this experiment!');
-            
+        function o = add(c,o)            
             % Add a plugin.
             if ~isa(o,'neurostim.plugin')
                 error('Only plugin derived classes can be added to CIC');


### PR DESCRIPTION
This change allows plugins to be added after calling c.run  (e.g. in beforeExperiment)

This allows Eyelink to load the sound plugin if it has not been loaded already (and therefore not messing with any sound plugins the user may have loaded already).

Note that c.run still checks that .used == false - so a cic object can still not be reused.

I don't see any downsides (except that a user could start adding plugins afterFrame() which is unlikely to result in a smooth experiment). 

There are probably other scenarios where adding a plugin during the experiment would not be crazy.... 

Alternative solutions are ugly (e.g. would require adding a "forceAdd" option to the plugin constructor, and the plugin.add function).
