### PR TITLE
Another bug fix

### DIFF
--- a/+neurostim/stimulus.m
+++ b/+neurostim/stimulus.m
@@ -368,7 +368,9 @@ classdef stimulus < neurostim.plugin
             if s.loc_disabled
                 % Diode flasher should match the stimulus state always,
                 % eevn if disabled
-                if s.diodeFlasher.enabled ; diodeFlasherOff(s,s.window);end
+                locWindow = s.window;
+                Screen('glLoadIdentity',locWindow);
+                if s.diodeFlasher.enabled ; diodeFlasherOff(s,locWindow);end
                 return;
             end
             
@@ -465,10 +467,12 @@ classdef stimulus < neurostim.plugin
         
         function baseBeforeItiFrame(s)
             if s.loc_disabled
+                locWindow = s.window;
+                Screen('glLoadIdentity',locWindow);                
                 if s.diodeFlasher.enabled; diodeFlasherOff(s,s.window);end                
                 return;
             end
-            % The flags.on parameter is used **as is** from the last frame
+            % The flags.on parameter is used **as is** from the l`ast frame
             % (frames are not updated in the ITI)                       
             locWindow = s.window;   
             if s.flags.on

--- a/+neurostim/stimulus.m
+++ b/+neurostim/stimulus.m
@@ -282,10 +282,14 @@ classdef stimulus < neurostim.plugin
         end
         
         function diodeFlasherOn(s,locWindow)
+            % Don't rotate or scale with the stimulus
+            Screen('glLoadIdentity', locWindow);
             Screen('FillRect',locWindow,s.diodeFlasher.onColor,s.diodeFlasher.position);
         end
         
         function diodeFlasherOff(s,locWindow)
+            % Don't rotate or scale with the stimulus
+            Screen('glLoadIdentity', locWindow);
             Screen('FillRect',locWindow,s.diodeFlasher.offColor,s.diodeFlasher.position);
         end
         
@@ -368,9 +372,7 @@ classdef stimulus < neurostim.plugin
             if s.loc_disabled
                 % Diode flasher should match the stimulus state always,
                 % eevn if disabled
-                locWindow = s.window;
-                Screen('glLoadIdentity',locWindow);
-                if s.diodeFlasher.enabled ; diodeFlasherOff(s,locWindow);end
+                if s.diodeFlasher.enabled ; diodeFlasherOff(s,s.window);end
                 return;
             end
             
@@ -440,15 +442,16 @@ classdef stimulus < neurostim.plugin
             end
 
             %% Flash
-            if s.diodeFlasher.enabled
-                Screen('glLoadIdentity',locWindow);% Don't rotate or scale with the stimulus
+            
+            if s.diodeFlasher.enabled        
                 if s.flags.on
                    diodeFlasherOn(s,locWindow);
                 else                                        
                    diodeFlasherOff(s,locWindow); 
                 end
             end
-            
+            % WARNING: the diode flasher flushes the coord system for this
+            % stim. No further drawing beyond this point.
         end
         
         function baseAfterFrame(s)
@@ -466,9 +469,7 @@ classdef stimulus < neurostim.plugin
         end
         
         function baseBeforeItiFrame(s)
-            if s.loc_disabled
-                locWindow = s.window;
-                Screen('glLoadIdentity',locWindow);                
+            if s.loc_disabled               
                 if s.diodeFlasher.enabled; diodeFlasherOff(s,s.window);end                
                 return;
             end
@@ -492,7 +493,7 @@ classdef stimulus < neurostim.plugin
             
             % diodeFlasher is in pixel coordinates, so after glLoadIdentity
             if s.diodeFlasher.enabled
-                Screen('glLoadIdentity', locWindow);
+     
                 % The diodeFlasher should reflect whether the stimulus is
                 % visible or not.
                 if s.flags.on && ~s.cic.itiClear
@@ -501,6 +502,8 @@ classdef stimulus < neurostim.plugin
                     diodeFlasherOff(s,locWindow); 
                 end       
             end
+            % WARNING: the diode flasher flushes the coord system for this
+            % stim. No further drawing beyond this point.
         end
         
         


### PR DESCRIPTION
The diode flasher was using wrong coordinate system when the stimulus was disabled and showing "offColor". 'nw' location was showing big black rectangle on top right. This fix was tested on my PC and Daisuke (from  Nic's lab) said that it looks OK in his rig too, but it involves a change to opengl stuff so would be good to have you look at it closely. Thanks.