### PR TITLE
Add a warning when loading a cic object from a crashed experiment.

### DIFF
--- a/+neurostim/cic.m
+++ b/+neurostim/cic.m
@@ -2175,7 +2175,11 @@ classdef cic < neurostim.plugin
                 storeInLog(c.prms.firstFrame,fakeFF,NaN)
             end
             
-            
+            % Check c.stage and issue a warning if this seems like a crashed session
+            if c.stage ~= neurostim.cic.POST
+                warning('This experiment ended unexpectedly (c.stage == %i; Should be %i). Some trials may be missing.', ...
+                    c.stage,neurostim.cic.POST);
+            end
             
         end
         


### PR DESCRIPTION
If neurostim crashes (or otherwise exist unexpectedly), the file
you're left with is a partial record of the experiment. It is possible
that additional trials were run that you now have no record of. This
can cause confusion when trying to reconcile data or events that may
have been recorded elsewhere (eye tracker, daq system etc.). This
change adds code to issue a warning when loading a partial save to
minimise confusion.