### PR TITLE
bug fix of movie.m

### DIFF
--- a/+neurostim/+stimuli/movie.m
+++ b/+neurostim/+stimuli/movie.m
@@ -73,7 +73,15 @@ classdef movie < neurostim.stimulus
                 file = fullfile(o.path,o.filename);
             end
             if strcmpi(o.currentlyLoadedFile,file)
-                % No need to reload
+                % No need to reload images
+                % but need to reload peripheral information
+                obj = VideoReader(file);                    
+                o.xPixels = obj.Width;
+                o.yPixels = obj.Height;
+                o.nrFrames = length(o.tex);
+                if isempty(o.framerate)
+                    o.framerate = obj.FrameRate;
+                end
             else
                 % Cleanup textures from the previous movie
                 Screen('Close',o.tex);


### PR DESCRIPTION
This fixes a minor bug preventing a single movie to be played multiple times. This was due to that some added properties (xPixels, yPixels, nrFrames, framerate) become empty after the 1st trial. In the fix, these properties were added in every trial.