### PR TITLE
Recreating saved dynprops

### DIFF
--- a/+neurostim/+stimuli/starstim.m
+++ b/+neurostim/+stimuli/starstim.m
@@ -95,7 +95,7 @@ classdef starstim < neurostim.stimulus
         eegInit= false; % Set to true to initialize eeg stream before experiment (and do not wait until the first trial with non empty o.eegChannels)
     end
     % Public Get, but set through functions or internally
-    properties (SetAccess=protected, GetAccess= public)
+    properties (SetAccess={?neurostim.plugin}, GetAccess= public)
         NICVersion;
         matNICVersion;
         code= containers.Map('KeyType','char','ValueType','double');
@@ -187,7 +187,7 @@ classdef starstim < neurostim.stimulus
             stop(o);
         end
         function disp(o)
-            disp(['Starstim Host: ' o.host  ' Status: ' o.status]);
+            disp(sprintf('Starstim Host: %s  Status: %s',o.host,o.status));
         end
         
         % Destructor
@@ -955,33 +955,13 @@ classdef starstim < neurostim.stimulus
     methods (Static)
         function o= loadobj(o)
             if isstruct(o)
-                % Update to current classdef.
+                % This saved object did not match the current classdef.
+                % Create a current class def
                 current = neurostim.stimuli.starstim(neurostim.cic('fromFile',true)); % Create current
-                fromFile = o;
-                %-- This cannot be moved to a function/script due to class access
-                %permissions.
-                m= metaclass(current);
-                dependent = [m.PropertyList.Dependent];
-                % Find properties that we can set now (based on the stored fromFile object)
-                settable = ~dependent & (strcmpi({m.PropertyList.SetAccess},'public') | strcmpi({m.PropertyList.SetAccess},'protected'));  %~strcmpi({m.PropertyList.SetAccess},'private') & ~[m.PropertyList.Constant];
-                storedFn = fieldnames(fromFile);
-                missingInSaved  = setdiff({m.PropertyList(settable).Name},storedFn);
-                missingInCurrent  = setdiff(storedFn,{m.PropertyList(~dependent).Name});
-                toCopy= intersect(storedFn,{m.PropertyList(settable).Name});
-                fprintf('Fixing backward compatibility of stored Neurostim object')
-                fprintf('\t Not defined when saved (will get current default values) : %s \n', missingInSaved{:})
-                fprintf('\t Not defined currently (will be removed) : %s \n' , missingInCurrent{:})
-                for i=1:numel(toCopy)
-                    try
-                        current.(toCopy{i}) = fromFile.(toCopy{i});
-                    catch
-                        fprintf('\t Failed to set %s(will get current default value)\n', toCopy{i})
-                    end
-                end
-                % ---
-                o = current;
+                % And use this to update the old one:
+                o = neurostim.plugin.updateClassdef(o,current);
             end
-            o.mustExit = false;
+            o.mustExit = false; % No active connection on load, so no need to exit.
         end
         
         function logOnset(s,flipTime)

--- a/+neurostim/+stimuli/starstim.m
+++ b/+neurostim/+stimuli/starstim.m
@@ -187,7 +187,7 @@ classdef starstim < neurostim.stimulus
             stop(o);
         end
         function disp(o)
-            disp(sprintf('Starstim Host: %s  Status: %s',o.host,o.status));
+            fprintf('Starstim Host: %s  Status: %s',o.host,o.status);
         end
         
         % Destructor
@@ -953,13 +953,16 @@ classdef starstim < neurostim.stimulus
     end
     
     methods (Static)
-        function o= loadobj(o)
+        % Classdef has changed over time; fix backward compatibility here. 
+        % This cannot be replaced with a generic plugin.loadoj as that function
+        % will not know what kind of object Matlab just tried to load.        
+        function o= loadobj(o) 
             if isstruct(o)
                 % This saved object did not match the current classdef.
                 % Create a current class def
                 current = neurostim.stimuli.starstim(neurostim.cic('fromFile',true)); % Create current
                 % And use this to update the old one:
-                o = neurostim.plugin.updateClassdef(o,current);
+                o = neurostim.plugin.updateClassDef(o,current);  % This updating is generic or all plugins
             end
             o.mustExit = false; % No active connection on load, so no need to exit.
         end

--- a/+neurostim/cic.m
+++ b/+neurostim/cic.m
@@ -480,10 +480,13 @@ classdef cic < neurostim.plugin
             if nargin<2
                 factors = [];
             end
+            blk = get(c.prms.block,'atTrialTime',0);
+            cnd = get(c.prms.condition,'atTrialTime',0);
             for b=1:numel(c.blocks)
-                blockStr = ['Block: ' num2str(b) '(' c.blocks(b).name ')'];
+                blockStr = ['Block: ' num2str(b) '(' c.blocks(b).name ') - ' num2str(sum(blk==b)) ' trials'];
+                condition = cnd(blk==b);                 
                 for d=1:numel(c.blocks(b).designs)
-                    show(c.blocks(b).designs(d),factors,blockStr);
+                    show(c.blocks(b).designs(d),factors,blockStr,condition);
                 end
             end
         end
@@ -2139,6 +2142,15 @@ classdef cic < neurostim.plugin
             end
             
             % Some postprocessing. 
+            
+            % The saved plugins still refer to the old-style (i.e. saved)
+            % cic. Update the handle
+            c.cic = c; % Self reference needed 
+           for p = c.pluginOrder
+               p.cic = c; % Point each plugin to the updated/new style cic.
+           end
+          
+            
             % If the last trial does not reach firstFrame, then
             % the trialTime (which is relative to firstFrame) cannot be calculated
             % This happens, for instance, when endExperiment is called by a plugin
@@ -2159,7 +2171,7 @@ classdef cic < neurostim.plugin
             % Check c.stage and issue a warning if this seems like a crashed session
             if c.stage ~= neurostim.cic.POST
                 warning('This experiment ended unexpectedly (c.stage == %i; Should be %i). Some trials may be missing.', ...
-                    c.stage,neurostim.cic.POST);
+                c.stage,neurostim.cic.POST);
             end
             
         end

--- a/+neurostim/cic.m
+++ b/+neurostim/cic.m
@@ -2127,7 +2127,7 @@ classdef cic < neurostim.plugin
         end
         
         function c = loadobj(o)
-            
+            % Classdef has changed over time - fix some things here.
             if isstruct(o)
                 % Current CIC classdef does not match classdef in force
                 % when this object was saved.
@@ -2135,12 +2135,13 @@ classdef cic < neurostim.plugin
                 current = neurostim.cic('fromFile',true); % Create an empty cic of current classdef that does not need PTB (loadedFromFile =true)                
                 % And upgrade the one that was stored using the plugin
                 % static member.
-                c = neurostim.plugin.updateClassdef(o,current);                
+                c = neurostim.plugin.updateClassDef(o,current);                
             else
-                c = o;
-                c.loadedFromFile = true; % Set to true to avoid PTB dependencies
+                % No need to call the plugin.loadobj
+                c = o;              
             end
             
+            c.loadedFromFile = true; % Set to true to avoid PTB dependencies
             % Some postprocessing. 
             
             % The saved plugins and parameters of CIC still refer to the old-style (i.e. saved)

--- a/+neurostim/cic.m
+++ b/+neurostim/cic.m
@@ -2143,11 +2143,12 @@ classdef cic < neurostim.plugin
             
             % Some postprocessing. 
             
-            % The saved plugins still refer to the old-style (i.e. saved)
+            % The saved plugins and parameters of CIC still refer to the old-style (i.e. saved)
             % cic. Update the handle
             c.cic = c; % Self reference needed 
-           for p = c.pluginOrder
-               p.cic = c; % Point each plugin to the updated/new style cic.
+            
+           for plg = c.pluginOrder
+               plg.cic = c; % Point each plugin to the updated/new style cic.
            end
           
             

--- a/+neurostim/cic.m
+++ b/+neurostim/cic.m
@@ -91,7 +91,7 @@ classdef cic < neurostim.plugin
     
     %% Protected properties.
     % These are set internally
-    properties (GetAccess=public, SetAccess =protected)
+    properties (GetAccess=public, SetAccess ={?neurostim.plugin})
         %% Program Flow
         mainWindow = []; % The PTB window
         overlayWindow =[]; % The color overlay for special colormodes (VPIXX-M16)
@@ -2128,36 +2128,17 @@ classdef cic < neurostim.plugin
             if isstruct(o)
                 % Current CIC classdef does not match classdef in force
                 % when this object was saved.
-                current = neurostim.cic('fromFile',true); % Create an empty cic of current classdef that does not need PTB (loadedFromFile =true)
-                fromFile = o;
-                %-- This cannot be moved to a function due to class access
-                %permissions.
-                m= metaclass(current);
-                dependent = [m.PropertyList.Dependent];
-                % Find properties that we can set now (based on the stored fromFile object)
-                settable = ~dependent & (strcmpi({m.PropertyList.SetAccess},'public') | strcmpi({m.PropertyList.SetAccess},'protected'));  %~strcmpi({m.PropertyList.SetAccess},'private') & ~[m.PropertyList.Constant];
-                storedFn = fieldnames(fromFile);
-                missingInSaved  = setdiff({m.PropertyList(settable).Name},storedFn);
-                missingInCurrent  = setdiff(storedFn,{m.PropertyList(~dependent).Name});
-                toCopy= intersect(storedFn,{m.PropertyList(settable).Name});
-                fprintf('Fixing backward compatibility of stored Neurostim object')
-                fprintf('\t Not defined when saved (will get current default values) : %s \n', missingInSaved{:})
-                fprintf('\t Not defined currently (will be removed) : %s \n' , missingInCurrent{:})
-                for i=1:numel(toCopy)
-                    try
-                        current.(toCopy{i}) = fromFile.(toCopy{i});
-                    catch
-                        fprintf('\t Failed to set %s(will get current default value)\n', toCopy{i})
-                    end
-                end
-                %---
-                c = current;
+                % Create an object according to the current classdef/
+                current = neurostim.cic('fromFile',true); % Create an empty cic of current classdef that does not need PTB (loadedFromFile =true)                
+                % And upgrade the one that was stored using the plugin
+                % static member.
+                c= neurostim.plugin.updateClassdef(o,current);                
             else
                 c = o;
                 c.loadedFromFile = true; % Set to true to avoid PTB dependencies
             end
             
-            
+            % Some postprocessing. 
             % If the last trial does not reach firstFrame, then
             % the trialTime (which is relative to firstFrame) cannot be calculated
             % This happens, for instance, when endExperiment is called by a plugin

--- a/+neurostim/parameter.m
+++ b/+neurostim/parameter.m
@@ -57,6 +57,8 @@ classdef parameter < handle & matlab.mixin.Copyable
          
         
         hDynProp;                   % Handle to the dynamic property. See pulgin.updateClassdef for why this needs plugin write access
+        plg; %@neurostim.plugin;    % Handle to the plugin that this belongs to.     
+
     end
     
     properties (SetAccess= protected, GetAccess=public)
@@ -73,7 +75,6 @@ classdef parameter < handle & matlab.mixin.Copyable
         funPrms;
         funStr = '';                % The neurostim function string
         validate =[];               % Validation function
-        plg; %@neurostim.plugin;    % Handle to the plugin that this belongs to.     
         hasLocalized;               % Flag to indicate whether the plugin has a localized variable for this parameter (i.e. loc_X for X). Detected on construction
     end
             

--- a/+neurostim/parameter.m
+++ b/+neurostim/parameter.m
@@ -54,6 +54,9 @@ classdef parameter < handle & matlab.mixin.Copyable
         % To set this for a previously defined parameter call
         % setChangesInTrial(plugin,parameterName) in your stimulus/plugin
         % class.
+         
+        
+        hDynProp;                   % Handle to the dynamic property. See pulgin.updateClassdef for why this needs plugin write access
     end
     
     properties (SetAccess= protected, GetAccess=public)
@@ -70,11 +73,10 @@ classdef parameter < handle & matlab.mixin.Copyable
         funPrms;
         funStr = '';                % The neurostim function string
         validate =[];               % Validation function
-        plg; %@neurostim.plugin;    % Handle to the plugin that this belongs to.
-        hDynProp;                   % Handle to the dynamic property
+        plg; %@neurostim.plugin;    % Handle to the plugin that this belongs to.     
         hasLocalized;               % Flag to indicate whether the plugin has a localized variable for this parameter (i.e. loc_X for X). Detected on construction
     end
-    
+            
     
     methods
         function  o = parameter(p,nm,v,h,options)

--- a/+neurostim/plugin.m
+++ b/+neurostim/plugin.m
@@ -845,12 +845,11 @@ classdef plugin  < dynamicprops & matlab.mixin.Copyable & matlab.mixin.Heterogen
             
             m= metaclass(current);
             dependent = [m.PropertyList.Dependent];
-            % Find properties that we can set now (based on the stored fromFile object)
-            settable = ~dependent & (strcmpi({m.PropertyList.SetAccess},'public') | strcmpi({m.PropertyList.SetAccess},'protected'));  %~strcmpi({m.PropertyList.SetAccess},'private') & ~[m.PropertyList.Constant];
+            % Find properties that we can set now (based on the stored fromFile object)            
             storedFn = fieldnames(old);
-            missingInSaved  = setdiff({m.PropertyList(settable).Name},storedFn);
+            missingInSaved  = setdiff({m.PropertyList(~dependent).Name},storedFn);
             missingInCurrent  = setdiff(storedFn,{m.PropertyList(~dependent).Name});
-            toCopy= intersect(storedFn,{m.PropertyList(settable).Name});
+            toCopy= intersect(storedFn,{m.PropertyList(~dependent).Name});
             fprintf('Fixing backward compatibility of stored %s object.\n',m.Name)
             fprintf('\t Not defined when saved (will get current default values) : %s \n', missingInSaved{:})
             fprintf('\t Not defined currently (will be removed) : %s \n' , missingInCurrent{:})

--- a/+neurostim/plugin.m
+++ b/+neurostim/plugin.m
@@ -847,12 +847,20 @@ classdef plugin  < dynamicprops & matlab.mixin.Copyable & matlab.mixin.Heterogen
             dependent = [m.PropertyList.Dependent];
             % Find properties that we can set now (based on the stored fromFile object)            
             storedFn = fieldnames(old);
-            missingInSaved  = setdiff({m.PropertyList(~dependent).Name},storedFn);
-            missingInCurrent  = setdiff(storedFn,{m.PropertyList(~dependent).Name});
+            missingInSaved  = strcat(setdiff({m.PropertyList(~dependent).Name},storedFn),' / ');
+            missingInCurrent  = strcat(setdiff(storedFn,{m.PropertyList(~dependent).Name}),' / ');
             toCopy= intersect(storedFn,{m.PropertyList(~dependent).Name});
-            fprintf('Fixing backward compatibility of stored %s object.\n',m.Name)
-            fprintf('\t Not defined when saved (will get current default values) : %s \n', missingInSaved{:})
-            fprintf('\t Not defined currently (will be removed) : %s \n' , missingInCurrent{:})
+            fprintf('Fixing backward compatibility of stored ***%s***object.\n',m.Name)
+            if ~isempty(missingInSaved)
+                fprintf('Not defined when saved (will get current default values):\n ');
+                fprintf('\t%s',missingInSaved{:})
+                fprintf('\n')
+            end
+            if ~isempty(missingInCurrent)
+                fprintf('Not defined currently (will be removed):\n');
+                fprintf('\t%s' ,missingInCurrent{:})
+                fprintf('\n');
+            end
             for i=1:numel(toCopy)
                 try
                     current.(toCopy{i}) = old.(toCopy{i});
@@ -860,6 +868,7 @@ classdef plugin  < dynamicprops & matlab.mixin.Copyable & matlab.mixin.Heterogen
                     fprintf('\t Failed to set %s(will get current default value): %s\n', toCopy{i},me.message)
                 end
             end
+            
             
             % Restore dynamic properties which appear to be lost (probably
             % because a struct (old) cannot have dynprops            
@@ -884,6 +893,10 @@ classdef plugin  < dynamicprops & matlab.mixin.Copyable & matlab.mixin.Heterogen
                 % last) value in the neurostim.parameter and never update.
                 hDynProp.GetMethod = @(varargin) (current.prms.(prmsNames{p}).value);
                 hDynProp.SetMethod = @(varargin) (NaN);
+                
+                % Then make sure the .plg member of the parameter links to
+                % the newly updated plg
+                current.prms.(prmsNames{p}).plg = current;
             end
         end
     end

--- a/+neurostim/plugin.m
+++ b/+neurostim/plugin.m
@@ -896,7 +896,17 @@ classdef plugin  < dynamicprops & matlab.mixin.Copyable & matlab.mixin.Heterogen
                 
                 % Then make sure the .plg member of the parameter links to
                 % the newly updated plg
-                current.prms.(prmsNames{p}).plg = current;
+                if p==1
+                    % This still points to the old style object. It will be
+                    % deleted when it goes out of scope, but if the
+                    % destructor references dynprops, it will generate an
+                    % warning. Instead delete it explicitly here, and hide the warning
+                    % to avoid confusion
+                    warning('off','MATLAB:class:DestructorError')
+                     delete(current.prms.(prmsNames{p}).plg);
+                    warning('on','MATLAB:class:DestructorError')                    
+                end
+                current.prms.(prmsNames{p}).plg = current;                
             end
         end
     end

--- a/+neurostim/stimulus.m
+++ b/+neurostim/stimulus.m
@@ -36,7 +36,7 @@ classdef stimulus < neurostim.plugin
         frame; % frame since start of stimulus
     end
     
-    properties (SetAccess = protected, GetAccess = public)
+    properties (SetAccess = {?neurostim.plugin}, GetAccess = public)
         flags = struct('on',true);
         stimstart = false;
         stimstop = false;


### PR DESCRIPTION
Fix a bug that prevents old datafiles from being loaded and used in an analysis due to missing dynamic properties.

Moved the code to update a saved object to the new (current) classdef to a shared function in plugin.
This requires giving the plugin class access to some of the (previously) protected properties of its child classes.

What is really new  (and not just moved) in this code is the re-establishing of dynamic properties at load time.
Probably because objects that no longer match the current classdef are converted to structs, their dynprops are lost.
I now recreate those, and make them read-only.  This avoids errors in plugin code that relies on the dynprops.

