### PR TITLE
listMod3rd

### DIFF
--- a/+neurostim/design.m
+++ b/+neurostim/design.m
@@ -376,6 +376,11 @@ classdef design <handle & matlab.mixin.Copyable
             end
         end
         
+        function setConditionOrder(o, condOrder)
+            o.randomization = 'MANUAL';
+            o.list = condOrder;
+        end
+        
         function shuffle(o)
             % Shuffle the list of conditions and set the "currentTrialIx" to
             % the first one in the list
@@ -390,6 +395,8 @@ classdef design <handle & matlab.mixin.Copyable
                     o.list=datasample(weighted,numel(weighted));
                 case 'RANDOMWITHOUTREPLACEMENT'
                     o.list=Shuffle(weighted);
+                case 'MANUAL'
+                    %do nothing
             end
             o.retryCounter = zeros(o.nrConditions,1);
             o.currentTrialIx =1; % Reset the index to start at the first entry


### PR DESCRIPTION
Followed the suggestion by Adam (https://github.com/klabhub/neurostim/pull/176#issuecomment-926133087). 
A new function SetConditionOrder specifies a manual list and convert o.randomization = 'MANUAL'.
shuffle remains intact. No added property to design.