### PR TITLE
Adaptive and behavior

### DIFF
--- a/+neurostim/+plugins/adaptive.m
+++ b/+neurostim/+plugins/adaptive.m
@@ -220,8 +220,7 @@ classdef (Abstract) adaptive < neurostim.plugin
             % for trials in which the behavior is not complete (i.e. success= false) 
            
             if isempty(o.design) || (strcmpi(o.cic.design,o.design) && ismember(o.cic.condition,o.conditions))% Check that this adaptive belongs to the current condition
-               if o.cic.trial > o.ignoreN  && trialSuccess(o.cic,o.requiredBehaviors)
-                   o.name
+               if o.cic.trial > o.ignoreN  && trialSuccess(o.cic,o.requiredBehaviors)                   
                     % Evaluate the function that the user provided (returning correct/incorrect) and store it.
                     %We'll use it to update the adaptive value in beforeTrial()
                     o.lastOutcome = o.trialOutcome;

--- a/+neurostim/+plugins/adaptive.m
+++ b/+neurostim/+plugins/adaptive.m
@@ -114,11 +114,17 @@ classdef (Abstract) adaptive < neurostim.plugin
     methods
 
         
-        function o = adaptive(c,funStr)
+        function o = adaptive(c,funStr,requiredBehaviors)
             % c= handle to CIC
             % fun = function string that evaluates to the outcome of the
             % trial (correct/incorrect).
-            
+            % requiredBehaviors = Cell array of names of behaviors that
+            % must be completed successfully before the adaptive parameter
+            % can be updated (e.g. 'fixation')
+            %            
+            if nargin <3
+                requiredBehaviors = '';
+            end
             % Create a name based on the child class and a unique ID.
             u =randi(2^53-1);
             s = dbstack;
@@ -130,6 +136,7 @@ classdef (Abstract) adaptive < neurostim.plugin
             o.addProperty('conditions',[]);% The condition that this adaptive parameter belongs to. Will be set by design.m
             o.addProperty('design',''); % This parm belongs to paramters in this design. (Set by design.m)
             o.addProperty('ignoreN',0); % Used to ignore the first N trials (set to 1 to ignroe the first, often missed trial)
+            o.addProperty('requiredBehaviors',requiredBehaviors); % These have to be successful for any update to occur
             o.uid = u;
             o.trialOutcome = funStr;
             
@@ -209,15 +216,18 @@ classdef (Abstract) adaptive < neurostim.plugin
             % Adaptive parameters defined as part of a design only get
             % updated when "their" condition/design is the currently active
             % one.
+            % In an experiment with required behaviors, outcomes are skipped
+            % for trials in which the behavior is not complete (i.e. success= false) 
+           
             if isempty(o.design) || (strcmpi(o.cic.design,o.design) && ismember(o.cic.condition,o.conditions))% Check that this adaptive belongs to the current condition
-               if o.cic.trial > o.ignoreN 
+               if o.cic.trial > o.ignoreN  && trialSuccess(o.cic,o.requiredBehaviors)
+                   o.name
                     % Evaluate the function that the user provided (returning correct/incorrect) and store it.
                     %We'll use it to update the adaptive value in beforeTrial()
                     o.lastOutcome = o.trialOutcome;
                     if numel(o.lastOutcome)>1 
                         error(['Your ''trialOutcome'' function in the adaptive parameter ' o.name ' does not evaluate to true or false']);
-                    end
-                    
+                    end                    
                     %Also store the value used
                     o.lastValue = o.getValue;
                else

--- a/+neurostim/block.m
+++ b/+neurostim/block.m
@@ -185,11 +185,7 @@ classdef block < dynamicprops
         end
         
         function afterTrial(o,c)
-            allBehaviors  = c.behaviors;
-            success = true;
-            for i=1:numel(allBehaviors)
-                success = success && (~allBehaviors(i).required || allBehaviors(i).isSuccess);
-            end
+            success = trialSuccess(c); % Success defined by all required behaviors
             o.nrRetried = o.nrRetried + afterTrial(o.design,success); % Update the design object
         end
         

--- a/+neurostim/cic.m
+++ b/+neurostim/cic.m
@@ -77,7 +77,7 @@ classdef cic < neurostim.plugin
             'experimenter',{[]},...% The keyboard that will handle keys for which isSubject is false (plugins by default)
             'pressAnyKey',{-1},... % Keyboard for start experiment, block ,etc. -1 means any
             'activeKb',{[]});  % Indices of keyboard that have keys associated with them. Set and used internally)
-       
+        
         %% Git version tracking
         % Set on=true to use version tracking. When false, no tracking is
         % used.
@@ -85,7 +85,7 @@ classdef cic < neurostim.plugin
         % commits are ignored).
         % Set silent = true to generate an automatic commit message (when
         % false, the user is asked to provide one).
-        % See neurostim.utils.git.versionTracker        
+        % See neurostim.utils.git.versionTracker
         gitTracker = struct('on',false,'silent',false,'commit',true);
     end
     
@@ -452,6 +452,24 @@ classdef cic < neurostim.plugin
             
         end
         
+        
+        function v = trialSuccess(c,behaviors)
+            % trialSuccess: True/False
+            % Returns whether this a successful trial (as defined by all or a subset of behaviors)
+            v = true;
+            
+            allBehaviors  = c.behaviors;
+            if nargin>1
+                stay = ismember({allBehaviors.name},behaviors);
+                allBehaviors= allBehaviors(stay);
+            end
+            
+            for i=1:numel(allBehaviors)
+                v = v && (~allBehaviors(i).required || allBehaviors(i).isSuccess);
+            end
+        end
+        
+        
         function showCursor(c,name)
             if nargin <2
                 name =c.cursor;
@@ -495,7 +513,7 @@ classdef cic < neurostim.plugin
                 c.(label) = value;
             end
         end
-                              
+        
         function addScript(c,when, fun,keys)
             % It may sometimes be more convenient to specify a function m-file
             % as the basic control script (rather than write a plugin that does
@@ -598,7 +616,7 @@ classdef cic < neurostim.plugin
                     newOrder = cat(2,'gui',newOrder(~isGui));
                 end
             end
-               
+            
             c.pluginOrder = [];
             for i=1:numel(newOrder)
                 c.pluginOrder =cat(2,c.pluginOrder,c.(newOrder{i}));
@@ -611,7 +629,7 @@ classdef cic < neurostim.plugin
         end
         
         function value = hasStimulus(c,stmName)
-            value = ~isempty(c.stimuli) && any(strcmpi(stmName,{c.stimuli.name}));            
+            value = ~isempty(c.stimuli) && any(strcmpi(stmName,{c.stimuli.name}));
         end
         
         function plgs = pluginsByClass(c,classType)
@@ -653,7 +671,7 @@ classdef cic < neurostim.plugin
             c.flags.experiment =false;
         end
         
-        function o = add(c,o)            
+        function o = add(c,o)
             % Add a plugin.
             if ~isa(o,'neurostim.plugin')
                 error('Only plugin derived classes can be added to CIC');
@@ -877,11 +895,11 @@ classdef cic < neurostim.plugin
             AssertOpenGL;
             sca; % Close any open PTB windows.
             
-            % Version tracking  at run time.          
+            % Version tracking  at run time.
             c.matlabVersion = version;
             c.ptbVersion = Screen('Version');
             c.repoVersion = neurostim.utils.git.versionTracker(c.gitTracker);
-                               
+            
             % Setup the messenger
             c.messenger.localCache = c.useFeedCache;
             c.messenger.useColor = c.useConsoleColor;
@@ -1057,13 +1075,13 @@ classdef cic < neurostim.plugin
                         % Let the GPU start processing this
                         Screen('DrawingFinished',c.mainWindow,1-clr);
                         
-                       
+                        
                         
                         KbQueueCheck(c);
                         % After the KB check, a behavioral requirement
                         % can have terminated the trial. Check for that.
                         if ~c.flags.trial ;  clr = c.itiClear; end % Do not clear this last frame if the ITI should not be cleared
-                         
+                        
                         if c.timing.vsyncMode ==1
                             % In vsyncMode 1 we schedule the flip now (but
                             % then proceed asynchronously to do some
@@ -1194,11 +1212,11 @@ classdef cic < neurostim.plugin
                         
                     end % Trial running
                     c.stage = neurostim.cic.RUNNING;
-                    % 
+                    %
                     % Call beforeItiFrame (can have some ITI drawing commands),
                     % then flip and clear (if requested)
                     base(c.pluginOrder,neurostim.stages.BEFOREITIFRAME,c);
-                    [~,ptbStimOn]=Screen('Flip', c.mainWindow,0,1-c.itiClear);                    
+                    [~,ptbStimOn]=Screen('Flip', c.mainWindow,0,1-c.itiClear);
                     clearOverlay(c,c.itiClear);
                     c.trialStopTime = ptbStimOn*1000;
                     
@@ -1233,8 +1251,8 @@ classdef cic < neurostim.plugin
             pruneLog([c.pluginOrder c]);
             
             if c.keyAfterExperiment
-              % need to do this before we kill CLUT textures etc.
-              c.drawFormattedText('Press any key to close the screen','ShowNow',true);
+                % need to do this before we kill CLUT textures etc.
+                c.drawFormattedText('Press any key to close the screen','ShowNow',true);
             end
             
             % clean up CLUT textures used by SOFTWARE-OVERLAY
@@ -1249,7 +1267,7 @@ classdef cic < neurostim.plugin
             ListenChar(0);
             Priority(0);
             if c.keyAfterExperiment
-              KbWait(c.kbInfo.pressAnyKey);
+                KbWait(c.kbInfo.pressAnyKey);
             end
             
             Screen('CloseAll');
@@ -1304,18 +1322,18 @@ classdef cic < neurostim.plugin
                     oldKey.help = c.kbInfo.help{ix};
                     oldKey.plg = c.kbInfo.plugin{ix};
                     oldKey.isSubject  = c.kbInfo.isSubject(ix);
-                    oldKey.fun  = c.kbInfo.fun{ix};                                          
+                    oldKey.fun  = c.kbInfo.fun{ix};
                 end
             else
                 oldKey = [];
                 ix = numel(c.kbInfo.keys)+1; % Add a new one
-            end            
+            end
             c.kbInfo.keys(ix)  = key;
             c.kbInfo.help{ix} = keyHelp;
             c.kbInfo.plugin{ix} = plg; % Handle to plugin to call keyboard()
             c.kbInfo.isSubject(ix) = isSubject;
-            c.kbInfo.fun{ix} = fun;            
-        end        
+            c.kbInfo.fun{ix} = fun;
+        end
         
         function removeKeyStroke(c,key)
             % removeKeyStrokes(c,key)
@@ -1375,7 +1393,7 @@ classdef cic < neurostim.plugin
                 c.lastFrameDrop=c.lastFrameDrop+nrFramedrops;
             end
         end
-
+        
         
         function addFunProp(c,plugin,prop)
             %Function properties are constructed at run-time
@@ -1625,7 +1643,7 @@ classdef cic < neurostim.plugin
                 end
             end
         end
-                
+        
     end
     
     methods (Access=private)
@@ -2018,7 +2036,7 @@ classdef cic < neurostim.plugin
         
         function colorOk = loadCalibration(c)
             colorOk = false;
-            if ~isempty(c.screen.calFile)                                               
+            if ~isempty(c.screen.calFile)
                 % Load a calibration from file. The cal struct has been
                 % generated by utils.ptbcal
                 
@@ -2280,7 +2298,7 @@ classdef cic < neurostim.plugin
             ylabel '#drops'
             
             if c.nrBehaviors>0
-                %% Compare frame drops to state transitions  
+                %% Compare frame drops to state transitions
                 % Currenlty only loking at the first transition iunto a
                 % state...
                 figure('Name',[c.file ' - framedrop report for behavior state changes'])
@@ -2289,7 +2307,7 @@ classdef cic < neurostim.plugin
                 colors = 'rgbcmyk';
                 for i=1:nrB
                     subplot(nrB,1,i)
-                    % Get first state transition in trials with drops, 
+                    % Get first state transition in trials with drops,
                     [state,stateTrial,stateStartT] = get(B(i).prms.state,'atTrialTime',[],'withDataOnly',true,'trial',unique(tr),'first',1);
                     uStates = unique(state);
                     for s=1:numel(uStates)
@@ -2297,7 +2315,7 @@ classdef cic < neurostim.plugin
                         thisTrials = stateTrial(thisState);
                         trialsWithStateAndDrops = tr(ismember(tr,thisTrials));
                         dropTime = ti(ismember(tr,trialsWithStateAndDrops));
-                        relativeTime = dropTime-stateStartT(trialsWithStateAndDrops);                                       
+                        relativeTime = dropTime-stateStartT(trialsWithStateAndDrops);
                         plot(relativeTime,trialsWithStateAndDrops,['o' colors(s)]);
                         hold on
                     end

--- a/demos/adaptiveDemo.m
+++ b/demos/adaptiveDemo.m
@@ -13,7 +13,7 @@ function adaptiveDemo
 % BK  - Nov 2016.
 
 import neurostim.*
-method = 'QUEST'; % Set this to QUEST or STAIRCASE
+method = 'STAIRCASE'; % Set this to QUEST or STAIRCASE
 pianola = true; % Set this to true to simulate responses, false to provide your own responses ('a'=left,'l' = right).
 
 
@@ -22,9 +22,9 @@ pianola = true; % Set this to true to simulate responses, false to provide your 
 % should converge on a low contrast, the other on a high contrast.
 % Note that this function should return the keyIndex of the correct key (so
 % 1 for 'a', 2 for 'l')
-%simulatedObserver = '@(grating.contrast<(0.1+0.5*(cic.condition-1)))+1.0';
+simulatedObserver = '@(grating.contrast<(0.1+0.5*(cic.condition-1)))+1.0';
 % Or use this one for an observer with some zero mean gaussian noise on the threshold
-simulatedObserver = '@(grating.contrast< (0.05*randn + (0.1+0.5*(cic.condition-1))))+1.0';
+%simulatedObserver = '@(grating.contrast< (0.5*randn + (0.1+0.5*(cic.condition-1))))+1.0';
 %% Setup the controller 
 c= myRig;
 c.trialDuration = Inf;
@@ -67,7 +67,55 @@ if pianola
     k.simWhat =  simulatedObserver;   % This function will provide a simulated answer
     k.simWhen = '@grating.on + grating.duration+50';  % At this time.
 end
+
 c.trialDuration = '@choice.stopTime';       %End the trial as soon as the 2AFC response is made.
+
+
+% There is a potentially tricky interaction between behavioral control (e.g. fixation)
+% and adaptive parameters. In the current example, on any trial that ends without
+% an answer (keypress), the choice object stores no response value,  then
+% choice.success evaluates to [] and that is the signal for the adaptive
+% parameter to ignore this trial for any updates. The components needed for
+% this are 1) a trial outcome function used for the adaptive parameter 
+% (here @choice.success) that evaluates to [] on
+% trials without a key press (the keyResponse object does this for you). 2)
+% a behavioral requirement that ends the trial prematurely. Here that is
+% achieved with fix.failEndsTrial = true;
+% 
+% However, you may not want to end a trial on a fixation break, or you also
+% want to discard adaptive parameter updates when a key has been pressed,
+% but some behavioral requirement (e.g. fixation) is not met *after* the key
+% press. For this, you specify the 'requiredBehaviors' of the adaptive
+% object. At the end of the trial (and before updating the adpative
+% parameter), the adaptive object will check whether these behaviors have
+% completed successfully and only then update the parameter.  By default no
+% behaviors are required. 
+
+%% Enforce fixation
+
+% Red fixation point
+f = stimuli.fixation(c,'reddot');       % Add a fixation point stimulus
+f.color             = [1 0 0];
+f.shape             = 'CIRC';           % Shape of the fixation point
+f.size              = 0.25;
+f.X                 = 0;
+f.Y                 = 0;
+f.on                = 0;                % On from the start of the trial
+
+%Make sure there is an eye tracker (or at least a virtual one)
+if isempty(c.pluginsByClass('eyetracker'))
+    e = neurostim.plugins.eyetracker(c);      %Eye tracker plugin not yet added, so use the virtual one. Mouse is used to control gaze position (click)
+    e.useMouse = true;
+end
+
+fix = behaviors.fixate(c,'fixation');
+fix.from            = 500;  % If fixation has not been achieved at this time, move to the next trial
+fix.to              = '@choice.stopTime';   % Require fixation until the choice is done.
+fix.X               = 0;
+fix.Y               = 0; 
+fix.tolerance       = 2;
+fix.failEndsTrial  = true;
+
 
 
 %% Setup the conditions in a design object
@@ -102,11 +150,15 @@ if strcmpi(method,'QUEST')
     % handles to the Quest object, not the object itself. In other words, if you used repmat you'd still use the
     % same Quest object for both orientations and could not estimate a
     % separate threshold per orientation.    
-    d.conditions(:,1).grating.contrast = duplicate(plugins.quest(c, '@choice.correct','guess',p2i(0.25),'guessSD',4,'i2p',i2p,'p2i',p2i),[nrLevels 1]);   
+    adpt = plugins.quest(c, '@choice.correct','guess',p2i(0.25),'guessSD',4,'i2p',i2p,'p2i',p2i);
+    adpt.requiredBehaviors = 'fixation';
+    d.conditions(:,1).grating.contrast = duplicate(adpt,[nrLevels 1]);   
 elseif strcmpi(method,'STAIRCASE')
     % As an alternative adaptive threshold estimation procedure, consider the 1-up 1-down staircase with fixed 0.01 stepsize on contrast.
     % With user responses, you use:
-    d.conditions(:,1).grating.contrast = duplicate(plugins.nDown1UpStaircase(c,'@choice.correct',rand,'min',0,'max',1,'weights',[1 1],'delta',0.1),[nrLevels 1]);
+    adpt = plugins.nDown1UpStaircase(c,'@choice.correct',rand,'min',0,'max',1,'weights',[1 1],'delta',0.1);
+    adpt.requiredBehaviors = 'fixation';
+    d.conditions(:,1).grating.contrast = duplicate(adpt,[nrLevels 1]);
 end
 
 % If you;d want to assign a different jitter object per condition (i.e. the

--- a/demos/taeDemo.m
+++ b/demos/taeDemo.m
@@ -1,4 +1,4 @@
-function tae
+function taeDemo
 %% 
 % Tilt AfterEffect Example
 % 


### PR DESCRIPTION
@alexanderATvision  noted that if some aspect of behavior (e.g. fixation) is not completed, an adaptive parameter (e.g. staircase) should probably not be updated  (even if the subject managed to give a response).  

Previously this could only be achieved by setting the behavior (e.g. fixation)  to be required and failEndsTrial to true. But if fail does not end the trial a  response would have been processed and used to update the adaptive parameter. 

This branch adds the option t add 'requiredBehaviors' to the adaptive parameter.
It is backward compatible (by default there are no requiredBehaviors)


The adaptiveDemo has some text and code to explain this new option.