### PR TITLE
Fix updating of adaptive plugins re: commit 6b6e581.

### DIFF
--- a/+neurostim/+plugins/adaptive.m
+++ b/+neurostim/+plugins/adaptive.m
@@ -166,7 +166,7 @@ classdef (Abstract) adaptive < neurostim.plugin
             
         end
         
-        function o= duplicate(o1,nm)
+        function o = duplicate(o1,nm)
             % Duplicate an adaptive parm ; requires setting a new unique
             % id. Note that if you ask for more than one duplicate, the
             % first element in the array of duplicates will be the
@@ -235,7 +235,7 @@ classdef (Abstract) adaptive < neurostim.plugin
             end
         end 
         
-        function beforeTrial(o)
+        function v = updateValue(o)
 
             if ~isempty(o.lastOutcome)
                 % Allow the derived class to update (based on lastValue and lastOutcome)
@@ -244,8 +244,10 @@ classdef (Abstract) adaptive < neurostim.plugin
                 o.lastValue = []; 
             end
             
-            %Reset the overruled value.
+            % Reset the overruled value.
             o.overruleValue = [];
+
+            v = getValue(o);
         end
     end
 end % classdef

--- a/+neurostim/block.m
+++ b/+neurostim/block.m
@@ -212,9 +212,9 @@ classdef block < dynamicprops
                 plgName =spcs{p,1};
                 varName = spcs{p,2};
                 if isa( spcs{p,3},'neurostim.plugins.adaptive')
-                    value = getValue(spcs{p,3});
+                    value = updateValue(spcs{p,3});
                 else
-                    value =  spcs{p,3};
+                    value = spcs{p,3};
                 end
                 c.(plgName).(varName) = value;
             end

--- a/+neurostim/cic.m
+++ b/+neurostim/cic.m
@@ -834,12 +834,22 @@ classdef cic < neurostim.plugin
             % Restore default values
             setDefaultParmsToCurrent(c.pluginOrder);
             
+            % Call before trial on all adaptive plugins, in pluginOrder.
+            %
+            % The adaptive plugin calls it's update() method in before
+            % trial... this needs to happen before we call before trial on
+            % the current block/design so that any adaptive parameters in
+            % the design are assigned their new/updated values.
+            ix = arrayfun(@(x) isa(x,'neurostim.plugins.adaptive'),c.pluginOrder);
+            base(c.pluginOrder(ix),neurostim.stages.BEFORETRIAL,c);
+
             % Call before trial on the current block.
             % This sets up all condition dependent stimulus properties (i.e. those in the design object that is currently active in the block)
             beforeTrial(c.blocks(c.block),c);
             c.blockTrial = c.blockTrial+1;  % For logging and user output only
+
             % Calls before trial on all plugins, in pluginOrder.
-            base(c.pluginOrder,neurostim.stages.BEFORETRIAL,c);
+            base(c.pluginOrder(~ix),neurostim.stages.BEFORETRIAL,c);
         end
         
         

--- a/+neurostim/cic.m
+++ b/+neurostim/cic.m
@@ -834,22 +834,14 @@ classdef cic < neurostim.plugin
             % Restore default values
             setDefaultParmsToCurrent(c.pluginOrder);
             
-            % Call before trial on all adaptive plugins, in pluginOrder.
-            %
-            % The adaptive plugin calls it's update() method in before
-            % trial... this needs to happen before we call before trial on
-            % the current block/design so that any adaptive parameters in
-            % the design are assigned their new/updated values.
-            ix = arrayfun(@(x) isa(x,'neurostim.plugins.adaptive'),c.pluginOrder);
-            base(c.pluginOrder(ix),neurostim.stages.BEFORETRIAL,c);
-
             % Call before trial on the current block.
-            % This sets up all condition dependent stimulus properties (i.e. those in the design object that is currently active in the block)
+            % This sets up all condition dependent stimulus properties (i.e.,
+            % those in the design object that is currently active in the block)
             beforeTrial(c.blocks(c.block),c);
             c.blockTrial = c.blockTrial+1;  % For logging and user output only
 
             % Calls before trial on all plugins, in pluginOrder.
-            base(c.pluginOrder(~ix),neurostim.stages.BEFORETRIAL,c);
+            base(c.pluginOrder,neurostim.stages.BEFORETRIAL,c);
         end
         
         


### PR DESCRIPTION
Commit 6b6e581 modified the adaptive base class to
call it's update() method in beforeTrial rather than
afterTrial. However, beforeTrial is only called on
plugins *after* beforeTrial is called on the current
block/design object. As a result, the design object
cannot know the new/updated value that should be
assigned to a parameter for the next trial. The design
object therefore (re-)assigns the value from the previous
trial. 

This change calls beforeTrial on any adaptive plugins
before calling beforeTrial on the current block/design.