### PR TITLE
Proposed fix for issue #190 (re: jittered parameters not updating)

### DIFF
--- a/+neurostim/block.m
+++ b/+neurostim/block.m
@@ -253,6 +253,20 @@ classdef block < dynamicprops
             waitForKey = o.beforeKeyPress && (~isempty(msg) || ~isempty(o.beforeFunction));
         end
         
+        function addAdaptive(o,plg,prm,obj)
+          % Add plg.prm = obj to each design
+          %
+          % Usage:
+          %
+          %   addAdaptive(o,plg,prm,obj) 
+          %
+          % where
+          %
+          %   plg - the name of a plugin
+          %   prm - the name of a parameter of plg
+          %   obj - an adaptive plugin object
+          arrayfun(@(x) addAdaptive(x,plg,prm,obj),o.designs);
+        end
     end % methods
     
 end % classdef

--- a/+neurostim/cic.m
+++ b/+neurostim/cic.m
@@ -952,6 +952,29 @@ classdef cic < neurostim.plugin
             %% Set up order and blocks
             order(c,c.pluginOrder);
             setupExperiment(c,block1,varargin{:});
+
+            % Force adaptive plugins assigned directly to parameters into
+            % the block design object(s) instead. This ensures the adaptive
+            % plugins are updated correctly (by the block object(s)).
+            plgs = c.order; % *all* plugins
+            for ii = 1:numel(plgs)
+              plg = plgs{ii}; 
+              prms = prmsByClass(c.(plg),'neurostim.plugins.adaptive');
+              if isempty(prms)
+                % no adaptive plugins/parameters
+                continue
+              end
+
+              for jj = 1:numel(prms)
+                prm = prms{jj};
+                obj = c.(plg).(prm);
+                c.(plg).(prm) = obj.getAdaptValue(); % default value?
+ 
+                % loop over blocks, adding plg.prm = obj
+                arrayfun(@(x) addAdaptive(x,plg,prm,obj),c.blocks);
+              end
+            end
+
             %%Setup PTB imaging pipeline and keyboard handling
             PsychImaging(c);
             checkFrameRate(c);

--- a/+neurostim/cic.m
+++ b/+neurostim/cic.m
@@ -956,24 +956,7 @@ classdef cic < neurostim.plugin
             % Force adaptive plugins assigned directly to parameters into
             % the block design object(s) instead. This ensures the adaptive
             % plugins are updated correctly (by the block object(s)).
-            plgs = c.order; % *all* plugins
-            for ii = 1:numel(plgs)
-              plg = plgs{ii}; 
-              prms = prmsByClass(c.(plg),'neurostim.plugins.adaptive');
-              if isempty(prms)
-                % no adaptive plugins/parameters
-                continue
-              end
-
-              for jj = 1:numel(prms)
-                prm = prms{jj};
-                obj = c.(plg).(prm);
-                c.(plg).(prm) = obj.getAdaptValue(); % default value?
- 
-                % loop over blocks, adding plg.prm = obj
-                arrayfun(@(x) addAdaptive(x,plg,prm,obj),c.blocks);
-              end
-            end
+            handleAdaptives(c)
 
             %%Setup PTB imaging pipeline and keyboard handling
             PsychImaging(c);
@@ -1797,9 +1780,31 @@ classdef cic < neurostim.plugin
             fprintf(1,'%s --> ', c.pluginOrder.name)
             disp('Parameter plugins should depend only on plugins with earlier execution (i.e. to the left)');
         end
-        
-        
-        
+            
+        function handleAdaptives(c)
+            % Force adaptive plugins assigned directly to parameters into
+            % the block design object(s) instead. This ensures the adaptive
+            % plugins are updated correctly (by the block object(s)).
+           
+            plgs = c.order; % *all* plugins
+            for ii = 1:numel(plgs)
+              plg = plgs{ii}; 
+              prms = prmsByClass(c.(plg),'neurostim.plugins.adaptive');
+              if isempty(prms)
+                % no adaptive plugins/parameters
+                continue
+              end
+
+              for jj = 1:numel(prms)
+                prm = prms{jj};
+                obj = c.(plg).(prm);
+                c.(plg).(prm) = obj.getAdaptValue(); % default value?
+ 
+                % loop over blocks, adding plg.prm = obj
+                arrayfun(@(x) addAdaptive(x,plg,prm,obj),c.blocks);
+              end
+            end
+        end
         %% PTB Imaging Pipeline Setup
         function PsychImaging(c)
             % Tthis initializes the

--- a/+neurostim/design.m
+++ b/+neurostim/design.m
@@ -402,6 +402,34 @@ classdef design <handle & matlab.mixin.Copyable
             o.currentTrialIx =1; % Reset the index to start at the first entry
         end
         
+        function addAdaptive(o,plg,prm,obj)
+          % If plg.prm is NOT part of the design, plg.prm = obj is added to each condition
+          % 
+          % Usage:
+          %
+          %   addAdaptive(o,plg,prm,obj)
+          %
+          % where
+          %
+          %   plg - the name of a plugin
+          %   prm - the name of a parameter of plg
+          %   obj - an adaptive plugin object
+          assert(isa(obj,'neurostim.plugins.adaptive'),'obj must be an adaptive plugin');
+
+          % if the specified plg.prm is not already part of the design,
+          % then we add plg.prm = obj to all conditions 
+          specs = cat(1,o.factorSpecs{:},o.conditionSpecs{:});
+
+          if any(strcmpi(specs(:,1),plg) & strcmpi(specs(:,2),prm))
+            % plg.prm is already part of the design... DO NOT overwrite it
+            return
+          end
+
+          % call subsasgn to add plg.prm = obj to all conditions... as if
+          % the user specified o.conditions(:).plg.prm = obj
+          o = subsasgn(o,struct('type',{'.','()','.','.'},'subs',{'conditions',{':'},plg,prm}),obj); %#ok<NASGU> 
+        end
+
         function o = subsasgn(o,S,V)
             % subsasgn to create special handling of .weights .conditions, and
             % .facN design specifications.

--- a/+neurostim/design.m
+++ b/+neurostim/design.m
@@ -426,7 +426,13 @@ classdef design <handle & matlab.mixin.Copyable
           end
 
           % call subsasgn to add plg.prm = obj to all conditions... as if
-          % the user specified o.conditions(:).plg.prm = obj
+          % the user specified o.conditions(:).(plg).(prm) = obj
+          %
+          % note: we can't just invoke o.conditions(:).(plg).(prm) = obj
+          %       here because MATLAB does not call the overloaded subsasgn
+          %       method within class methods.
+          %
+          % https://au.mathworks.com/help/releases/R2021a/matlab/matlab_oop/indexed-reference-and-assignment.html#br09nsm
           o = subsasgn(o,struct('type',{'.','()','.','.'},'subs',{'conditions',{':'},plg,prm}),obj); %#ok<NASGU> 
         end
 

--- a/+neurostim/plugin.m
+++ b/+neurostim/plugin.m
@@ -176,6 +176,13 @@ classdef plugin  < dynamicprops & matlab.mixin.Copyable & matlab.mixin.Heterogen
             o.prms.(parm.name) = duplicate(parm,o,h);
         end
         
+        function prms = prmsByClass(o,cls)
+          % return the names of the ns parameters that are
+          % instances of the class specified by cls
+          prms = fieldnames(o.prms);
+          ix = cellfun(@(x) isa(o.(x),cls),prms);
+          prms(~ix) = [];
+        end
         
         
         function tbl = getBIDSTable(o,varargin)

--- a/demos/adaptiveDemo.m
+++ b/demos/adaptiveDemo.m
@@ -1,4 +1,4 @@
-function adaptiveDemo
+function adaptiveDemo(varargin)
 % Demo to show adaptive threshold estimation.
 %
 % The subjects task is to detect the location of a Gabor:  left (press
@@ -26,7 +26,8 @@ simulatedObserver = '@(grating.contrast<(0.1+0.5*(cic.condition-1)))+1.0';
 % Or use this one for an observer with some zero mean gaussian noise on the threshold
 %simulatedObserver = '@(grating.contrast< (0.5*randn + (0.1+0.5*(cic.condition-1))))+1.0';
 %% Setup the controller 
-c= myRig;
+c= myRig(varargin{:});
+
 c.trialDuration = Inf;
 c.screen.color.background = [ 0.5 0.5 0.5];
 c.subjectNr= 0;

--- a/demos/behaviorDemo.m
+++ b/demos/behaviorDemo.m
@@ -74,6 +74,7 @@ d.maxRadius = 5;
 d.lifetime = Inf;
 d.noiseMode = 0;
 d.coherence = 0.6;
+d.size =  plugins.jitter(c,{2, 4, 8},'distribution','1ofn'); %Randomly choose size from 3 possible values everall trial, in all conditions
 
 % You can use a photo diode to check stimulus timing. This command will
 % show a small (0.02 of the horizontal screen size) blue square in the northeast corner of the screen
@@ -124,7 +125,7 @@ myDesign.fac1.fix.X=   [-10 0 10];             %Three different fixation positio
 myDesign.fac2.dots.direction=[-90 90];         %Two dot directions
 % Jitter the Y position in all conditions of the 2-factor design (you have
 % to explicitly specify two ':' to represent the two factors, a single (:) is interpreted as a single factor and will fail.)
-myDesign.conditions(:,:).fix.Y =  plugins.jitter(c,{0,4},'distribution','normal','bounds',[-5 5]);   %Vary Y-coord randomly from trial to trial (truncated Gaussian)
+myDesign.conditions(:,:).fix.Y =  plugins.jitter(c,{0,4},'distribution','normal','bounds',[-5 5]);   %Vary Y-coord randomly from trial to trial (truncated Gaussian). Alternative syntax to direct assignment (cf. dots.size above)
 % By default, an incorrect answer is simply ignored (i.e. the condition is not repeated).
 % This corresponds to myDesign.retry ='IGNORE';
 % To repeat a condition immediately if the behavioral requiremnts are not met (e.g. during trainig) , specify


### PR DESCRIPTION
This change proposes to fix issue #190 wherein parameters that are directly assigned a jitter object (actually any adaptive object) are not updated between trials.

In #188 we decoupled the updating of adaptive parameters from beforeTrial by placing the update code in the code that sets the design specs. We did that so that the update automatically happened before all the other plugins' beforeTrial code (which potentially depend on the adaptive parameter). Importantly, any beforeTrial method defined in an adaptive object will be called along with all the other beforeTrial methods, respecting the plugin order. 

That all works well for adaptive objects that are assigned as part of a design object BUT the update code was no longer being called for adaptive objects that were assigned directly to parameters outside of a design.

After discussion with @adammorrissirrommada, we here propose to address this issue by treating adaptive parameters a bit more like the way we handle parameters that are assigned neurostim function strings. Specifically, in cic.run() we locate all neurostim parameters that have been directly assigned adaptive objects and move those adaptive objects to the design object(s).

This allows the user the convenience of assigning adaptive objects directly to parameters if they want that parameter 'adapted' in all conditions, but ensures that all adaptive parameters are updated before all other beforeTrial methods, as required.

Importantly, an adaptive object is NOT added to the design spec if the corresponding plugin.param combination is already part of the design. In effect, assignment by the user within a design trumps any direct assignment.