### PR TITLE
Adaptive parm fix again

### DIFF
--- a/+neurostim/+plugins/adaptive.m
+++ b/+neurostim/+plugins/adaptive.m
@@ -146,6 +146,7 @@ classdef (Abstract) adaptive < neurostim.plugin
             if ~isempty(o.design) && ~strcmpi(o.design,dsgn)
                 error('Not sure this works... one adaptive parm belongs to two designs?');
             end
+            assert(isnumeric(cond),'Conditions should be listed as numbers');
             o.design = dsgn;
             o.conditions = unique(cat(1,o.conditions,cond));
         end

--- a/+neurostim/cic.m
+++ b/+neurostim/cic.m
@@ -301,7 +301,7 @@ classdef cic < neurostim.plugin
                 c.screen.height = c.screen.ypixels;
             end
             if ~isequal(round(c.screen.xpixels/c.screen.ypixels,2),round(c.screen.width/c.screen.height,2))
-                warning('Physical aspect ratio and Pixel aspect ration are  not the same...');
+                warning('Physical aspect ratio and Pixel aspect ratio are not the same...');
             end
         end
         

--- a/+neurostim/design.m
+++ b/+neurostim/design.m
@@ -407,10 +407,11 @@ classdef design <handle & matlab.mixin.Copyable
             % a plugin (and not part of the design). For consistency
             % in updating these are added to the design object (and applied
             % to all conditions, except those conditions where the same
-            % parameter is already set).  In other words, the design
+            % parameter is already set in the design).  In other words, the design
             % overrules any values set directly to the object (as it does
-            % for other, non-adaptive, parameters, in a condition-specific
-            % manner.
+            % for other, non-adaptive, parameters) and it does so in a 
+            % condition-specific manner.  (i.e. condition 4 can be set in
+            % the design, while 3 keeps its default value from the plugin)
             %
             % Usage:
             %
@@ -606,7 +607,7 @@ classdef design <handle & matlab.mixin.Copyable
                         % d.conditions([1:4]).bla.x = 1;
                         % Note that the value is assigned to each condition
                         % (so no 'deal()' functionality)
-                        assert(iscell(ix) && numel(ix)==1,'subasgn received noncell or nonscalar input')
+                        assert(iscell(ix) && numel(ix)==1,'subasgn received noncell or nonscalar ix')
                         if ischar(ix{1}) && strcmpi(ix{1},':')
                             % Replace : with  1:end
                             lvls = o.nrLevels;

--- a/+neurostim/design.m
+++ b/+neurostim/design.m
@@ -79,7 +79,7 @@ classdef design <handle & matlab.mixin.Copyable
     %  d.conditions(:,2).dots.X = plugins.jitter(...)
     %
     % Note that in this case, the adaptive plugin Jitter is shared acrosss
-    % all levels that use t (i.e. the same underlying jitter object generates the
+    % all levels that use it (i.e. the same underlying jitter object generates the
     % values). This is desirable for Jitter, but not for some staircases.
     % To use separate staircases for each level of a factor,use the
     % duplicate function:
@@ -89,14 +89,14 @@ classdef design <handle & matlab.mixin.Copyable
     % TK, BK, 2016
     % Feb-2017 BK
     % Major redesign without backward compatibility
-    
+
     properties  (SetAccess =public, GetAccess=public)
         randomization='RANDOMWITHOUTREPLACEMENT';
         retry = 'IGNORE'; %IGNORE,IMMEDIATE,RANDOM
         weights=1;               % The relative weight of each condition. (Must be scalar or the same size as specs)
         maxRetry = Inf;
     end
-    
+
     properties         (SetAccess =protected, GetAccess=public)
         name;                      % The name of this design; bookkeeping/logging use only.
         factorSpecs={};            % A cell array of condition specifications for factorial designs
@@ -105,7 +105,7 @@ classdef design <handle & matlab.mixin.Copyable
         currentTrialIx =0;                   % The condition that will be run in this trial (index in to .list)
         retryCounter = [];
     end
-    
+
     properties (Dependent)
         nrConditions;                   % The total number of conditions in this design
         nrFactors;                      % The number fo factors in the design
@@ -117,41 +117,41 @@ classdef design <handle & matlab.mixin.Copyable
         condition;                      % Linear index of the current condition
         nrRetried;                      % The total number of trials that have been retried.
     end
-    
-    
+
+
     methods  %/get/set
-        
+
         function v= get.done(o)
             % Returns true if the currentTrialIx points to zero or the last
             % trial.
             v = ismember(o.currentTrialIx ,[0 o.nrTrials]);
         end
-        
+
         function v = get.nrTrials(o)
             v= numel(o.list); % All trials, including retries
         end
-        
+
         function v=get.nrPlannedTrials(o)
             % Total number of trial in this design (this includes the
             % effect of weighting, but not the retried-trials) (so it
             % reflects the number of planned trials).
             v = numel(o.list)-o.nrRetried;
         end
-        
+
         function v = get.nrRetried(o)
             v = sum(o.retryCounter);
         end
-        
+
         function v= get.nrFactors(o)
             %Number of factors in the design
             v = size(o.factorSpecs,1);
         end
-        
+
         function v=get.nrConditions(o)
             % The number of conditions in this design
             v=prod(o.nrLevels);
         end
-        
+
         function v=get.nrLevels(o)
             % Number of levels in each of the factors. For a non-factorial
             % design this returns [nrConditions 1]
@@ -164,29 +164,29 @@ classdef design <handle & matlab.mixin.Copyable
                 v= [v 1];
             end
         end
-        
+
         function v = get.levels(o)
             % The currrent condition as a subscript into
             % the factorial design: % [2 3] = 2nd level first factor, 3rd level 2nd factor.
             % For a non-factorial design this is [i 1] with i the condition
             v= cond2lvl(o,o.condition);
         end
-        
+
         function v = get.condition(o)
             % Linear index for the current condition
             v= o.list(o.currentTrialIx);
         end
-        
+
     end
-    
-    
+
+
     methods (Access = public)
-        
+
         function v= specs(o,cond)
             % Return a cell array with the specifcations for one
             % condition. If no second argument is provided, it returns the
             % specs for the current condition.
-            
+
             if nargin <2
                 cond = o.condition;
             end
@@ -194,7 +194,7 @@ classdef design <handle & matlab.mixin.Copyable
             if isscalar(lvls)
                 lvls = [lvls 1];
             end
-            
+
             % lvls and cond provide the same information, the former is easier for
             % factorSpecs , the latter for conditionSpecs
             v={};
@@ -240,8 +240,8 @@ classdef design <handle & matlab.mixin.Copyable
                 end
             end
         end
-        
-        
+
+
         function show(o,f,str)
             % Function to show the condition specifications in a figure.
             % f - the dimensions of the design to show (e.g. [1 2] to
@@ -266,7 +266,7 @@ classdef design <handle & matlab.mixin.Copyable
             end
             spcs = reshape(spcs,o.nrLevels);
             others = setdiff(1:o.nrFactors,f);
-            
+
             if numel(f)>1
                 spcs = permute(spcs,[f others]);
                 wghts = permute(o.weights,[f others]);
@@ -285,7 +285,7 @@ classdef design <handle & matlab.mixin.Copyable
             ylim([0.5 nrY+.5]);
             zlim([0.5 nrZ+0.5]);
             set(gca,'XTick',1:nrX,'YTick',1:nrY,'ZTick',1:nrZ);
-            
+
             ylabel(['Factor #' num2str(f(1))])
             if nrX>1
                 xlabel(['Factor #' num2str(f(2))])
@@ -329,12 +329,12 @@ classdef design <handle & matlab.mixin.Copyable
             % name - name of this design object
             o.name = nm;
         end
-        
+
         function o2=duplicate(o1,nm)
             o2 =copyElement(o1);
             o2.name = nm;
         end
-        
+
         % Called from block/afterTrial with information ont he success of
         % the previous trial. If success is false, the trial can be repeated
         % at a later time.
@@ -343,7 +343,7 @@ classdef design <handle & matlab.mixin.Copyable
                 retry = 0;
                 return; % Nothing do do: either we don't want to retry, or we've retried the max already.
             end
-            
+
             switch upper(o.retry)
                 case 'IMMEDIATE'
                     insertIx = o.currentTrialIx +1 ;
@@ -364,7 +364,7 @@ classdef design <handle & matlab.mixin.Copyable
             retry = 1;
             o.retryCounter(o.condition) = o.retryCounter(o.condition) +1;  % Count the retries
         end
-        
+
         function ok = beforeTrial(o)
             % Move the index to the next condition in the trial list.
             % Returns false if this is not possible (i.e. the design has been run completely).
@@ -375,12 +375,12 @@ classdef design <handle & matlab.mixin.Copyable
                 o.currentTrialIx =o.currentTrialIx +1;
             end
         end
-        
+
         function setConditionOrder(o, condOrder)
             o.randomization = 'MANUAL';
             o.list = condOrder;
         end
-        
+
         function shuffle(o)
             % Shuffle the list of conditions and set the "currentTrialIx" to
             % the first one in the list
@@ -401,61 +401,61 @@ classdef design <handle & matlab.mixin.Copyable
             o.retryCounter = zeros(o.nrConditions,1);
             o.currentTrialIx =1; % Reset the index to start at the first entry
         end
-        
+
         function addAdaptive(o,plg,prm,obj)
-          % If plg.prm is NOT part of the design, plg.prm = obj is added to each condition
-          % 
-          % Usage:
-          %
-          %   addAdaptive(o,plg,prm,obj)
-          %
-          % where
-          %
-          %   plg - the name of a plugin
-          %   prm - the name of a parameter of plg
-          %   obj - an adaptive plugin object
-          assert(isa(obj,'neurostim.plugins.adaptive'),'obj must be an adaptive plugin');
+            % If plg.prm is NOT part of the design, plg.prm = obj is added to each condition
+            %
+            % Usage:
+            %
+            %   addAdaptive(o,plg,prm,obj)
+            %
+            % where
+            %
+            %   plg - the name of a plugin
+            %   prm - the name of a parameter of plg
+            %   obj - an adaptive plugin object
+            assert(isa(obj,'neurostim.plugins.adaptive'),'obj must be an adaptive plugin');
 
-          % if the specified plg.prm is not already part of the design,
-          % then we add plg.prm = obj to all conditions 
-          specs = cat(1,o.factorSpecs{:},o.conditionSpecs{:});
+            % if the specified plg.prm is not already part of the design,
+            % then we add plg.prm = obj to all conditions
+            specs = cat(1,o.factorSpecs{:},o.conditionSpecs{:});
 
-          if any(strcmpi(specs(:,1),plg) & strcmpi(specs(:,2),prm))
-            % plg.prm is already part of the design... DO NOT overwrite it
-            return
-          end
+            if any(strcmpi(specs(:,1),plg) & strcmpi(specs(:,2),prm))
+                % plg.prm is already part of the design... DO NOT overwrite it
+                return
+            end
 
-          % call subsasgn to add plg.prm = obj to all conditions... as if
-          % the user specified o.conditions(:).(plg).(prm) = obj
-          %
-          % note: we can't just invoke o.conditions(:).(plg).(prm) = obj
-          %       here because MATLAB does not call the overloaded subsasgn
-          %       method within class methods.
-          %
-          % https://au.mathworks.com/help/releases/R2021a/matlab/matlab_oop/indexed-reference-and-assignment.html#br09nsm
-          o = subsasgn(o,struct('type',{'.','()','.','.'},'subs',{'conditions',{':'},plg,prm}),obj); %#ok<NASGU> 
+            % call subsasgn to add plg.prm = obj to all conditions... as if
+            % the user specified o.conditions(:).(plg).(prm) = obj
+            %
+            % note: we can't just invoke o.conditions(:).(plg).(prm) = obj
+            %       here because MATLAB does not call the overloaded subsasgn
+            %       method within class methods.
+            %
+            % https://au.mathworks.com/help/releases/R2021a/matlab/matlab_oop/indexed-reference-and-assignment.html#br09nsm
+            o = subsasgn(o,struct('type',{'.','()','.','.'},'subs',{'conditions',{':'},plg,prm}),obj); %#ok<NASGU>
         end
 
         function o = subsasgn(o,S,V)
             % subsasgn to create special handling of .weights .conditions, and
             % .facN design specifications.
             handled = false; % If not handled here, we call the builtin below.
-            
+
             if strcmpi(S(1).type,'.')
                 if strcmpi(S(1).subs,'WEIGHTS')
                     handled =true;
-                    
+
                     %Disallow cell
                     if ~isnumeric(V)
                         error(['Factorial design weights must be a numeric array, but a ', class(V) ' was encountered. Type help neurostim.design']);
                     end
-                    
+
                     %If a vector of weights (i.e. a one-factor design), make a
                     %column vector (to match up with the nLevels x 1 output of o.nrLevels
                     if isvector(V)
                         V = V(:);
                     end
-                    
+
                     if numel(V) ==1 || isequal(size(V),o.nrLevels)
                         o.weights = V;
                     else
@@ -502,21 +502,21 @@ classdef design <handle & matlab.mixin.Copyable
                         %% Factors have previously been defined. Allow only
                         % modifications of the full factorial, not
                         % conditions that are outside the factorial
-                        
+
                         % Allow users to use singleton or vectors to specify
                         % levels (if the parameter value of a single level is a
                         % vector, put it in a cell array).
-                        
+
                         lvls = o.nrLevels;
-                        
-                        
+
+
                         for f=1:o.nrFactors
                             if strcmpi(ix{f},':')
                                 % Replace : with  1:end
                                 ix{f} = 1:lvls(f);
                             end
                         end
-                        
+
                         if ischar(V) || (~iscell(V) && isscalar(V))
                             V = {V};
                         elseif ~iscell(V)
@@ -526,7 +526,7 @@ classdef design <handle & matlab.mixin.Copyable
                             if numel(nrInTrg)==numel(nrInSrc) && all(nrInTrg==nrInSrc)
                                 match = true;
                             end
-                            
+
                             if ~match
                                 % trg could have trailing singleton
                                 % dimensions.
@@ -534,7 +534,7 @@ classdef design <handle & matlab.mixin.Copyable
                                 matchingDims = 1:nrMatchingDims;
                                 match = all(nrInTrg(matchingDims)==nrInSrc(matchingDims)) && all(nrInTrg(nrMatchingDims+1:end)==1) && all(nrInSrc(nrMatchingDims+1:end)==1);
                             end
-                            
+
                             if match
                                 % This is a matrix where each element is
                                 % intended as a level for a factor.
@@ -545,7 +545,7 @@ classdef design <handle & matlab.mixin.Copyable
                                 V = {V};
                             end
                         end
-                        
+
                         for f=1:o.nrFactors
                             if ~(numel(V)==1 || size(V,f) == numel(ix{f}))
                                 error(['The number of values on the RHS [' num2str(size(V)) '] does not match the number specified on the LHS [' num2str(lvls) ']']);
@@ -559,14 +559,14 @@ classdef design <handle & matlab.mixin.Copyable
                             error(['Some conditions do not fit in the [' num2str(lvls) '] factorial. Use a separate design for these conditions']);
                         end
                         %% Everything should match, lets assign
-                        
+
                         % we know the number of factors and the number of
                         % levels for each... initialize o.conditionSpecs if
                         % it hasn't been initialized already
                         if isempty(o.conditionSpecs)
                             o.conditionSpecs = cell(o.nrLevels);
                         end
-                        
+
                         for i=1:size(ix,1)
                             trgSub = neurostim.utils.vec2cell(ix(i,:));
                             if numel(V) == 1
@@ -578,7 +578,7 @@ classdef design <handle & matlab.mixin.Copyable
                             if isa(thisV,'neurostim.plugins.adaptive')
                                 thisV.belongsTo(o.name,o.lvl2cond(ix(i,:))); % Tell the adaptive to listen to this design/level combination
                             end
-                            
+
                             % add to previous, or replace if it refers to the same property
                             curSpecs = o.conditionSpecs{trgSub{:}};
                             if ~isempty(curSpecs)
@@ -592,20 +592,33 @@ classdef design <handle & matlab.mixin.Copyable
                             o.conditionSpecs{trgSub{:}} = cat(1,curSpecs,{plg,prm,thisV});
                         end
                     else
-                        %% Conditions-only design, specified one at a time
-                        %d.conditions(1).bla.x = 1;
-                        if numel(ix)>1 || numel(ix{1})>1
-                            error('A pure .conditions design must be specified one condition at a time');
+                        %% Conditions-only design
+                        % d.conditions(1).bla.x = 1;
+                        % d.conditions([1:4]).bla.x = 1;
+                        % Note that the value is assigned to each condition
+                        % (so no 'deal()' functionality)
+                        assert(iscell(ix) && numel(ix)==1,'subasgn received noncell or nonscalar input')
+                        if ischar(ix{1}) && strcmpi(ix{1},':')
+                            % Replace : with  1:end
+                            lvls = o.nrLevels;
+                            assert(lvls(2)==1,'This should not happen.... warn a programmer.')
+                            ix = 1:lvls(1);  %dim 2 =levels of factors but this is conditions only so 1.
+                        else
+                            ix = ix{1};
+                            assert(isnumeric(ix),sprintf('The indices (ix) used for design.conditions(ix).%s.%s = are not numeric',plg,prm))
                         end
-                        ix = ix{1};
+                       
                         if  isa(V,'neurostim.plugins.adaptive')
                             V.belongsTo(o.name,ix); % Tell the adaptive to listen to this design/level combination
                         end
-                        assert(~strcmpi(plg,'cic'),['Parameters of cic (' prm ') cannot be included in a design object. You may get the desired functionality by defining a parameter in another plugin/stimulus and then use a neurostim function to define the CIC propert (e.g. c.trialDuration = ''@myStimulus.trialDuration'')']);                        
-                        if ix> numel(o.conditionSpecs)  || isempty(o.conditionSpecs{ix})
-                            o.conditionSpecs{ix} = {plg,prm,V};
-                        else
-                            o.conditionSpecs{ix} = cat(1,o.conditionSpecs{ix},{plg,prm,V});
+                        assert(~strcmpi(plg,'cic'),['Parameters of cic (' prm ') cannot be included in a design object. You may get the desired functionality by defining a parameter in another plugin/stimulus and then use a neurostim function to define the CIC propert (e.g. c.trialDuration = ''@myStimulus.trialDuration'')']);
+                        for thisIx = ix
+                            if thisIx > numel(o.conditionSpecs)  || isempty(o.conditionSpecs{thisIx})
+                                o.conditionSpecs{thisIx ,1} = {plg,prm,V}; % first one for this condition
+                            else
+                                % Add to specs that already exist
+                                o.conditionSpecs{thisIx ,1} = cat(1,o.conditionSpecs{thisIx ,1},{plg,prm,V});
+                            end
                         end
                     end
                 elseif strncmpi(S(1).subs,'FAC',3)
@@ -656,7 +669,7 @@ classdef design <handle & matlab.mixin.Copyable
                     else
                         % New factor.
                     end
-                    
+
                     % Now loop through all the new values and store them in
                     % the factorSpecs cell array [nrFactors, nrLevels]
                     % factor 1: level1 level2...
@@ -677,7 +690,7 @@ classdef design <handle & matlab.mixin.Copyable
                     end
                 end
             end
-            
+
             %% We're only handling a small subset  of subsasgn here, the rest is passed
             % to builtin
             if ~handled
@@ -686,12 +699,12 @@ classdef design <handle & matlab.mixin.Copyable
             end
         end
     end
-    
+
     methods (Access=protected)
         function o1= copyElement(o2)
             o1 = copyElement@matlab.mixin.Copyable(o2);
         end
-        
+
         function v= cond2lvl(o,cond)
             % Return the factor levels for a specified condition
             if o.nrFactors>0
@@ -702,7 +715,7 @@ classdef design <handle & matlab.mixin.Copyable
                 v = [cond 1];
             end
         end
-        
+
         function v = lvl2cond(o,lvl)
             %Return the condition number for a specific multidimensional level index.
             lvl = neurostim.utils.vec2cell(lvl);

--- a/+neurostim/design.m
+++ b/+neurostim/design.m
@@ -621,7 +621,7 @@ classdef design <handle & matlab.mixin.Copyable
                         if  isa(V,'neurostim.plugins.adaptive')
                             V.belongsTo(o.name,ix); % Tell the adaptive to listen to this design/level combination
                         end
-                        assert(~strcmpi(plg,'cic'),['Parameters of cic (' prm ') cannot be included in a design object. You may get the desired functionality by defining a parameter in another plugin/stimulus and then use a neurostim function to define the CIC propert (e.g. c.trialDuration = ''@myStimulus.trialDuration'')']);
+                        assert(~strcmpi(plg,'cic'),['Parameters of cic (' prm ') cannot be included in a design object. You may get the desired functionality by defining a parameter in another plugin/stimulus and then use a neurostim function to define the CIC property (e.g. c.trialDuration = ''@myStimulus.trialDuration'')']);
                         for thisIx = ix
                             if thisIx > numel(o.conditionSpecs)  || isempty(o.conditionSpecs{thisIx})
                                 o.conditionSpecs{thisIx ,1} = {plg,prm,V}; % first one for this condition

--- a/demos/adaptiveDemo.m
+++ b/demos/adaptiveDemo.m
@@ -22,9 +22,9 @@ pianola = true; % Set this to true to simulate responses, false to provide your 
 % should converge on a low contrast, the other on a high contrast.
 % Note that this function should return the keyIndex of the correct key (so
 % 1 for 'a', 2 for 'l')
-simulatedObserver = '@(grating.contrast<(0.1+0.5*(cic.condition-1)))+1.0';
+simulatedObserver = '@iff(grating.contrast < (0.1+0.5*(cic.condition-1)),~(grating.X > 0),grating.X > 0) + 1.0';
 % Or use this one for an observer with some zero mean gaussian noise on the threshold
-%simulatedObserver = '@(grating.contrast< (0.5*randn + (0.1+0.5*(cic.condition-1))))+1.0';
+%simulatedObserver = '@iff(grating.contrast < (0.5*randn + (0.1+0.5*(cic.condition-1))),~(grating.X > 0),grating.X > 0) + 1.0';
 %% Setup the controller 
 c= myRig(varargin{:});
 

--- a/demos/adaptiveDemo.m
+++ b/demos/adaptiveDemo.m
@@ -22,9 +22,9 @@ pianola = true; % Set this to true to simulate responses, false to provide your 
 % should converge on a low contrast, the other on a high contrast.
 % Note that this function should return the keyIndex of the correct key (so
 % 1 for 'a', 2 for 'l')
-simulatedObserver = '@iff(grating.contrast < (0.1+0.5*(cic.condition-1)),~(grating.X > 0),grating.X > 0) + 1.0';
+simulatedObserver = '@iff(grating.contrast > (0.1+0.5*(cic.condition-1)),grating.X > 0,rand < 0.5) + 1.0';
 % Or use this one for an observer with some zero mean gaussian noise on the threshold
-%simulatedObserver = '@iff(grating.contrast < (0.5*randn + (0.1+0.5*(cic.condition-1))),~(grating.X > 0),grating.X > 0) + 1.0';
+%simulatedObserver = '@iff(grating.contrast > (0.5*randn + (0.1+0.5*(cic.condition-1))),grating.X > 0,rand < 0.5) + 1.0';
 %% Setup the controller 
 c= myRig(varargin{:});
 

--- a/tools/adaptiveParmTest.m
+++ b/tools/adaptiveParmTest.m
@@ -3,7 +3,7 @@ function c= adaptiveParmTest
 % A previous NS version failed to set/update a default jitter if the design
 % only had a condition (and not factors).
 % Run this, then check
-% c.blocks(1).design.specs(1)
+%  c.blocks(1).design.specs(1)
 % It shoud have two jitter objects, one for X, one for orientation.
 %  c.blocks(1).design.specs(2)
 % Should have a constant value (10) for X and a jitter for Y
@@ -12,31 +12,31 @@ function c= adaptiveParmTest
 import neurostim.*
 
 %% Setup the controller
-c= myRig('debug',true);
+c = myRig('debug',true);
 c.trialDuration = Inf;
 c.screen.color.background = [ 0.5 0.5 0.5];
 c.subjectNr= 0;
 
 %% Add a Gabor;
 g=stimuli.gabor(c,'grating');
-g.color             = [0.5 0.5 0.5];
+g.color            = [0.5 0.5 0.5];
 g.contrast         = 0.25;
-g.Y                     = 0;
-g.X                     = neurostim.plugins.jitter(c,{-10,10});
-g.sigma             = 3;
-g.phaseSpeed   = 0;
-g.orientation     = 0;
-g.mask               = 'CIRCLE';
+g.Y                = 0;
+g.X                = neurostim.plugins.jitter(c,{-10,10});
+g.sigma            = 3;
+g.phaseSpeed       = 0;
+g.orientation      = 0;
+g.mask             = 'CIRCLE';
 g.frequency        = 3;
-g.on                    =  0;
-g.duration          = 500;
+g.on               = 0;
+g.duration         = 500;
 
 %% Setup the conditions in a design object
 d=design('orientation');
-d.conditions(1).grating.orientation =    neurostim.plugins.jitter(c,{-45,45},'distribution','1ofN');
+d.conditions(1).grating.orientation = neurostim.plugins.jitter(c,{-45,45},'distribution','1ofN');
 
-d.conditions(2).grating.Y=    neurostim.plugins.jitter(c,{-10,10});
-d.conditions(2).grating.X=    0;  % Overrules the jitter assigned to the object
+d.conditions(2).grating.Y = neurostim.plugins.jitter(c,{-10,10});
+d.conditions(2).grating.X = 10;  % Overrules the jitter assigned to the object
 d.randomization = 'sequential';
 % Create a block for this design and specify the repeats per design
 myBlock=block('myBlock',d);

--- a/tools/adaptiveParmTest.m
+++ b/tools/adaptiveParmTest.m
@@ -6,7 +6,7 @@ function c= adaptiveParmTest
 % c.blocks(1).design.specs(1)
 % It shoud have two jitter objects, one for X, one for orientation.
 %  c.blocks(1).design.specs(2)
-% Should have one for X and one for Y
+% Should have a constant value (10) for X and a jitter for Y
 % BK  - April 2022.
 
 import neurostim.*
@@ -34,11 +34,15 @@ g.duration          = 500;
 %% Setup the conditions in a design object
 d=design('orientation');
 d.conditions(1).grating.orientation =    neurostim.plugins.jitter(c,{-45,45},'distribution','1ofN');
+
 d.conditions(2).grating.Y=    neurostim.plugins.jitter(c,{-10,10});
-d.conditions(2).grating.X=    0;
+d.conditions(2).grating.X=    0;  % Overrules the jitter assigned to the object
 d.randomization = 'sequential';
 % Create a block for this design and specify the repeats per design
 myBlock=block('myBlock',d);
-myBlock.nrRepeats = 10; 
+myBlock.nrRepeats = 1; 
 c.trialDuration = 250;
 c.run(myBlock);
+%% Show
+c.blocks(1).design.specs(1)
+c.blocks(1).design.specs(2)

--- a/tools/adaptiveParmTest.m
+++ b/tools/adaptiveParmTest.m
@@ -1,0 +1,44 @@
+function c= adaptiveParmTest
+% Demo to test that adaptive parms are set correctly
+% A previous NS version failed to set/update a default jitter if the design
+% only had a condition (and not factors).
+% Run this, then check
+% c.blocks(1).design.specs(1)
+% It shoud have two jitter objects, one for X, one for orientation.
+%  c.blocks(1).design.specs(2)
+% Should have one for X and one for Y
+% BK  - April 2022.
+
+import neurostim.*
+
+%% Setup the controller
+c= myRig('debug',true);
+c.trialDuration = Inf;
+c.screen.color.background = [ 0.5 0.5 0.5];
+c.subjectNr= 0;
+
+%% Add a Gabor;
+g=stimuli.gabor(c,'grating');
+g.color             = [0.5 0.5 0.5];
+g.contrast         = 0.25;
+g.Y                     = 0;
+g.X                     = neurostim.plugins.jitter(c,{-10,10});
+g.sigma             = 3;
+g.phaseSpeed   = 0;
+g.orientation     = 0;
+g.mask               = 'CIRCLE';
+g.frequency        = 3;
+g.on                    =  0;
+g.duration          = 500;
+
+%% Setup the conditions in a design object
+d=design('orientation');
+d.conditions(1).grating.orientation =    neurostim.plugins.jitter(c,{-45,45},'distribution','1ofN');
+d.conditions(2).grating.Y=    neurostim.plugins.jitter(c,{-10,10});
+d.conditions(2).grating.X=    0;
+d.randomization = 'sequential';
+% Create a block for this design and specify the repeats per design
+myBlock=block('myBlock',d);
+myBlock.nrRepeats = 10; 
+c.trialDuration = 250;
+c.run(myBlock);


### PR DESCRIPTION
1. This fixes one bug following #191  :

 Adaptive parameters assigned directly to an object were not added to the design correctly if the design contained only conditions and no factors. 

2. And it changes the way adaptive parameters are overruled by the design :

Since #191, a single condition in the design (for a plugin and parameter that also had an adaptive parameter assigned to a property directly), resulted in the adaptive parameter being ignored for all conditions. That is contrary to the way default values are handled for other (nonadaptive) parameters. I changed this now so that a design overrules an adaptive in a condition-specific manner. 

See tools/adaptiveParmTest.m for a quick test/illustration. 