### PR TITLE
Add logging of remote Eyelink edf filename

### DIFF
--- a/+neurostim/+plugins/eyelink.m
+++ b/+neurostim/+plugins/eyelink.m
@@ -67,7 +67,8 @@ classdef eyelink < neurostim.plugins.eyetracker
     properties
         el; %@struct;  % Information structure to communicate with Eyelink host
         commands = {'link_sample_data = GAZE'};
-        edfFile = 'test.edf';
+        edfFile = '';
+        edfFileRemote = '';
         getSamples =true;
         getEvents =false;
         nTransferAttempts = 5;
@@ -180,10 +181,14 @@ classdef eyelink < neurostim.plugins.eyetracker
             Eyelink('command', 'sample_rate = %d',o.sampleRate);
             
             
-            % open file to record data to (will be renamed on copy)
+            % Create a temporary file anme to use on Eyelink remote PC
+            % side. Will be renamed to default ns format on transfer
+            % afterExperiment
             [~,tmpFile] = fileparts(tempname);
-            o.edfFile= [tmpFile(end-7:end) '.edf']; %8 character limit
-            Eyelink('Openfile', o.edfFile);
+            o.edfFileRemote = [tmpFile(end-7:end) '.edf']; %8 character limit in Eyelink software
+            
+            % open file to record data to (will be renamed on copy)
+            Eyelink('Openfile', o.edfFileRemote);
             
             switch upper(o.eye)
                 case 'LEFT'
@@ -294,19 +299,19 @@ classdef eyelink < neurostim.plugins.eyetracker
                 try
                     newFileName = [o.cic.fullFile '.edf'];
                     for i=1:o.nTransferAttempts
-                        status=Eyelink('ReceiveFile',o.edfFile,newFileName); %change to OUTPUT dir
+                        status=Eyelink('ReceiveFile',o.edfFileRemote,newFileName); %change to OUTPUT dir
                         if status>0
                             o.edfFile = newFileName;
                             writeToFeed(o,['Success: transferred ' num2str(status) ' bytes']);
                             break
                         else
                             o.nTransferAttempts = o.nTransferAttempts - 1;
-                            writeToFeed(o,['Fail: EDF file (' o.edfFile ')  did not transfer ' num2str(status)]);
+                            writeToFeed(o,['Fail: EDF file (' o.edfFileRemote ')  did not transfer ' num2str(status)]);
                             writeToFeed(o,['Retrying. ' num2str(o.nTransferAttempts) ' attempts remaining.']);
                         end
                     end
                 catch
-                    error(horzcat('Eyelink file transfer failed. Saved on Eyelink PC as ',o.edfFile));
+                    error(horzcat('Eyelink file transfer failed. Saved on Eyelink PC as ',o.edfFileRemote));
                 end
             end
             Eyelink('Shutdown');


### PR DESCRIPTION
Some lab members have found that they need to know the name of the temp remote edf file after an experiment.
This commit does mean that the original property `edfFile` now stores only the ns formatted name and is empty until a successful transfer happens (previously it held the temp name). Instead `edfFileRemote` holds the temp file name throughout the experiment. This opens a narrow door for a backwards compatibility issue if someone has written code to resurrect failed sessions using `edfFile,` but I think that's very unlikely and easily fixed.