### PR TITLE
Fix direct assignment of adaptive objects for designs with multiple factors.

### DIFF
--- a/+neurostim/design.m
+++ b/+neurostim/design.m
@@ -492,7 +492,10 @@ classdef design <handle & matlab.mixin.Copyable
                         end
                     else
                         targetFactors = S(2).subs;
-                        if o.nrFactors >0 && (targetFactors{end}~=1 && numel(targetFactors) ~= o.nrFactors && ~(numel(targetFactors)==1 && strcmpi(targetFactors{1},':'))) % allow (:,1) for a one-factor
+                        if o.nrFactors >0 && ( ...
+                            targetFactors{end}~=1 && numel(targetFactors) ~= o.nrFactors && ... % allow (:,1) for a one-factor
+                            ~(numel(targetFactors)==1 && strcmpi(targetFactors{1},':')) && ... % allow (:)
+                            ~(numel(targetFactors)==1 && isnumeric(targetFactors{1})) ) % allow use of linear indicies
                             error(['Specify an entry for each of the ' num2str(o.nrFactors) ' dimensions of .conditions'])
                         end
                     end
@@ -507,6 +510,10 @@ classdef design <handle & matlab.mixin.Copyable
                         % Singleton expansion of (:) to  (:,:)
                         ix = cell(1,o.nrFactors);
                         [ix{:}] = deal(':');
+                    end
+                    if numel(ix)==1 && o.nrFactors>1
+                        % Linear index... convert to subscripts
+                        [ix{1:o.nrFactors}] = ind2sub(o.nrLevels,ix{1});
                     end
                     if o.nrFactors>0
                         %% Factors have previously been defined. Allow only


### PR DESCRIPTION
Recent changes to handling of adaptive objects (c.f., ca6c17b) cause direct assignment of an adaptive object to a parameter to fail for designs with multiple factors. See for example demos/behaviorDemo.m on the current master branch (c.f., 6c7aa72).

This is because `design.addAdaptive()` calls `design.subsasgn()` with a linear index into `.conditions`, but `design.subsasgn()` does not currently handle linear indices.

I think there are two possible solutions here:

1. Modify `design.addAdaptive()` to pass subscripts (rather than linear indices) in it's call to `design.subsasgn()`, or
2. Modify `design.subsasgn()` to accept linear indices in assignments to `.conditions`.

This change implements the second option.

Is there any reason that linear indices should _not_ be allowed in assignments to `.conditions`?
