### PR TITLE
Modify storeInLog() to check for equality of NaNs.

### DIFF
--- a/+neurostim/parameter.m
+++ b/+neurostim/parameter.m
@@ -174,7 +174,7 @@ classdef parameter < handle & matlab.mixin.Copyable
             % Check if the value changed and log only the changes.
             % (at some point this seemed to be slower than just logging everything.
             % but tests on July 1st 2017 showed that this was (no longer) correct.
-            if  (isnumeric(v) && numel(v)==numel(o.value) && isnumeric(o.value) && all(v(:)==o.value(:))) || (ischar(v) && ischar(o.value) && strcmp(v,o.value))
+            if  (isnumeric(v) && numel(v)==numel(o.value) && isnumeric(o.value) && isequaln(v(:),o.value(:))) || (ischar(v) && ischar(o.value) && strcmp(v,o.value))
                 % No change, no logging.
                 return;
             end


### PR DESCRIPTION
`parameter.storeInLog()` is intended to only log changes to a
parameter's value. However, at present, assignment of NaN to a
parameter can lead to excessive logging if the parameter's
.value is already NaN.

This is because the current test `all(v(:) == o.value(:))` is
false if both `v` and `o.value` are NaN.

This can become a problem if a function string, evaluated every
frame, evaluates to NaN leading to a NaN being logged every frame.

This change proposes to use `isequaln(v(:),o.value(:))` in place
of the existing `all(v(:) == o.value(:))`.

`isequaln()` was introduced in R2012a.