### PR TITLE
debug noiseclut

### DIFF
--- a/+neurostim/+stimuli/noiseclut.m
+++ b/+neurostim/+stimuli/noiseclut.m
@@ -229,6 +229,9 @@ classdef (Abstract) noiseclut < neurostim.stimuli.clutImage
                 %anything. That said, everything should work fine as long
                 %as their function does not depend on any other property
                 %values that changed throughout the experiment.
+                if ~iscell(o.sampleFun)
+                    o.sampleFun = {o.sampleFun}; 
+                end 
                 if any(cellfun(@(x) isa(x,'function_handle'),o.sampleFun))
                     if ~warned
                         warning('This stimulus used a user-defined function to set the luminance/color of the randels. The reconstruction might fail if your custom function calls upon any Neurostim parameters other than o.nRandels and o.ixImage). We really have no way to know what you did!');


### PR DESCRIPTION
noiseclut.samplefun is assumed to be a cell but sometimes it is  not. This fix foces samplefun to be a cell (addressing the issue #201)