### PR TITLE
openEphys ZMQ 

### DIFF
--- a/+neurostim/+plugins/openEphys.m
+++ b/+neurostim/+plugins/openEphys.m
@@ -97,8 +97,10 @@ classdef openEphys < neurostim.plugins.ePhys
             sendMessage(o,'StartAcquisition');
             o.connectionStatus = true; % <-- FIXME: is this used/useful for anything?
             
-            pause(o.startDelay);
-
+            if o.startDelay>0
+                pause(o.startDelay);
+            end
+            
             % Generate command string that is used to initiate recording and specify save information  
             request = sprintf('StartRecord CreateNewDir=%i RecDir=%s PrependText=%s AppendText=%s', ...
                 o.createNewDir, o.recDir, o.prependText, o.appendText);

--- a/+neurostim/+plugins/openEphys.m
+++ b/+neurostim/+plugins/openEphys.m
@@ -57,6 +57,7 @@ classdef openEphys < neurostim.plugins.ePhys
             pin.addParameter('RecDir', '', @ischar); % save path on the open ephys computer
             pin.addParameter('PrependText', '', @ischar); 
             pin.addParameter('AppendText', '', @ischar);
+            pin.addParameter('startDelay',0, @isnumeric);
             
             pin.parse(varargin{:});
             
@@ -73,6 +74,7 @@ classdef openEphys < neurostim.plugins.ePhys
             o.addProperty('recDir',args.RecDir,'validate',@ischar); 
             o.addProperty('prependText',args.PrependText,'validate',@ischar); 
             o.addProperty('appendText',args.AppendText,'validate',@ischar);                                   
+            o.addProperty('startDelay',args.startDelay,'validate',@isnumeric);
         end
         
         function sendMessage(o,msg)
@@ -95,6 +97,8 @@ classdef openEphys < neurostim.plugins.ePhys
             sendMessage(o,'StartAcquisition');
             o.connectionStatus = true; % <-- FIXME: is this used/useful for anything?
             
+            pause(o.startDelay);
+
             % Generate command string that is used to initiate recording and specify save information  
             request = sprintf('StartRecord CreateNewDir=%i RecDir=%s PrependText=%s AppendText=%s', ...
                 o.createNewDir, o.recDir, o.prependText, o.appendText);


### PR DESCRIPTION
In some rigs, openEphys software crashes if it receives "startAcquisition" and "startRecord" messages from neurostim pc without interval. To mitigate this problem, I added a new parameter "startDelay" in openEphys plugin, which imposes a specified delay between the two messages.