### PR TITLE
Fix a plugin (re-)ordering bug (re: #200).

### DIFF
--- a/+neurostim/cic.m
+++ b/+neurostim/cic.m
@@ -1790,9 +1790,9 @@ classdef cic < neurostim.plugin
             % the block design object(s) instead. This ensures the adaptive
             % plugins are updated correctly (by the block object(s)).
            
-            plgs = c.order; % *all* plugins
+            plgs = {c.pluginOrder.name}; % *all* plugins
             for ii = 1:numel(plgs)
-              plg = plgs{ii}; 
+              plg = plgs{ii};
               prms = prmsByClass(c.(plg),'neurostim.plugins.adaptive');
               if isempty(prms)
                 % no adaptive plugins/parameters


### PR DESCRIPTION
This change fixes a bug introduced by commit 1988ab5 (re: #190)
that causes any changes to the default plugin order, imposed in
cic.run(), to be immediately reverted when handling adaptive
plugins/parameters (see cic.handleAdaptives()).

This change removes the call to c.order(), which reverts the plugin
order, in favour of using c.pluginOrder directly.