### PR TITLE
control rdp random number seed

### DIFF
--- a/+neurostim/+stimuli/rdp.m
+++ b/+neurostim/+stimuli/rdp.m
@@ -68,6 +68,10 @@ classdef rdp < neurostim.stimulus
         
         function beforeTrial(o)
             
+            if ~isempty(o.rngSeed)
+                rng(o.rngSeed);%reset random number generator 
+            end 
+            
             % overrule one of the velocity vectors based on coord system
             if o.coordSystem == 1
                 [o.direction, o.speed] = cart2pol(o.xspeed, o.yspeed);

--- a/+neurostim/+stimuli/rdp.m
+++ b/+neurostim/+stimuli/rdp.m
@@ -63,7 +63,7 @@ classdef rdp < neurostim.stimulus
             o.addProperty('noiseDist',0,'validate',@(x)x==0||x==1);       % gaussian, uniform
             o.addProperty('noiseWidth',50,'validate',@isnumeric);
             o.addProperty('truncateGauss',-1,'validate',@isnumeric);
-            o.addProperty('tngSeed',[]);
+            o.addProperty('rngSeed',[]);
         end
         
         

--- a/+neurostim/+stimuli/rdp.m
+++ b/+neurostim/+stimuli/rdp.m
@@ -63,6 +63,7 @@ classdef rdp < neurostim.stimulus
             o.addProperty('noiseDist',0,'validate',@(x)x==0||x==1);       % gaussian, uniform
             o.addProperty('noiseWidth',50,'validate',@isnumeric);
             o.addProperty('truncateGauss',-1,'validate',@isnumeric);
+            o.addProperty('tngSeed',[]);
         end
         
         

--- a/+neurostim/+stimuli/rdp.m
+++ b/+neurostim/+stimuli/rdp.m
@@ -139,6 +139,11 @@ classdef rdp < neurostim.stimulus
         function initialiseDots(o,pos)
             % initialises dots in the array positions given by logical
             % array pos.
+            
+            if ~isempty(o.rngSeed)
+                rng(o.rngSeed);%reset random number generator 
+            end
+            
             nnzpos=nnz(pos);
             o.framesLeft(pos,1) = o.lifetime;
             o.radius(pos,1) = sqrt(rand(nnzpos,1).*o.maxRadius.*o.maxRadius);


### PR DESCRIPTION
I'd like to add an option to control the random number generator.
This will enable to
1) realize the same dot pattern across trials
2) realize the same dot pattern across different rdp instances, presented at once