### PR TITLE
Add check on rsvp design specs in .addRSVP().

### DIFF
--- a/+neurostim/stimulus.m
+++ b/+neurostim/stimulus.m
@@ -195,6 +195,16 @@ classdef stimulus < neurostim.plugin
             p.addParameter('isi',0,@(x) isnumeric(x) & x >= 0);
             p.addParameter('log',false,@islogical);
             p.parse(design,varargin{:});
+
+            for spec = design.factorSpecs(:)'
+                if isempty(spec{1}), continue; end
+
+                if any(~strcmp(spec{1}(:,1),s.name))
+                    error('Design object ''%s'' assigned to the rsvp of ''%s'' cannot contain factor specs that modify other plugins.', ...
+                        design.name,s.name)
+                end
+            end
+
             flds = fieldnames(p.Results);
             for i=1:numel(flds)
                 s.rsvp.(flds{i}) = p.Results.(flds{i});


### PR DESCRIPTION
This commit adds a check that the design object used for rsvp of a stimulus only modifies properties of that stimulus and produces and error if that isn't the case.

This is consistent with the existing behaviour of .updateRSVP() but prevents a design object being assigned to the rsvp that tries to modify some other plugin. At present that is possible, but leads to a) an error at runtime when .updateRSVP() tries to update a property that doesn't exist, or
b) incorrect, but silent, modification of the current stimulus' property if it happens to match the name of the property of the other plugin named in the spec.
Both outcomes are clearly undesirable.