### PR TITLE
Fixed bug in getting block number

### DIFF
--- a/+neurostim/parameter.m
+++ b/+neurostim/parameter.m
@@ -556,7 +556,7 @@ classdef parameter < handle & matlab.mixin.Copyable
             
             if nargout >4 || p.Results.struct
                 % User asked for block information
-                block= get(o.plg.cic.prms.block,'atTrialTime',Inf,'matrixIfPossible',false); % Blck at end of trial
+                block= get(o.plg.cic.prms.block,'atTrialTime',0,'matrixIfPossible',false); % Blck at end of trial
                 block = [block{trial}]'; % Match other info that is returned. Make it a column vector to match other data/trial info.
             end
             


### PR DESCRIPTION
WARNING: potentially affects someone's existing analysis (unlikely)

The output of `parameter.get()` includes the block number if requested. There is a bug for the last trial of every block in which the returned block number is actually off by +1. It's due to the use of `'atTrialTime', Inf` in the internal (recursive) call to `get()`, because  the block number ticks over before the trial number does in the `run()` loop. The fix is to just use time zero rather than Inf.