### PR TITLE
Modified gabor shader to work with colorMode LINLUT.

### DIFF
--- a/+neurostim/+stimuli/GLSLShaders/gabor.frag.txt
+++ b/+neurostim/+stimuli/GLSLShaders/gabor.frag.txt
@@ -122,14 +122,14 @@ void main()
     }
 
     factor =  1.0 +contrast * ev * sv * tev;
-    if (colorMode==1 || colorMode==3){
-        /*  RGB or LUM */
+    if (colorMode==1 || colorMode==3 || colorMode==4){
+        /*  RGB, LUM or LINLUT */
         gl_FragColor[0] = color[0] * factor;
         gl_FragColor[1] = color[1] * factor;
         gl_FragColor[2] = color[2] * factor;
         gl_FragColor[3] = alpha*color[3];
     }else if (colorMode ==2) {
-            /* xyL */
+        /* xyL */
         gl_FragColor[0] = color[0];
         gl_FragColor[1] = color[1];
         gl_FragColor[2] = color[2] *factor;

--- a/+neurostim/+stimuli/gabor.m
+++ b/+neurostim/+stimuli/gabor.m
@@ -195,7 +195,7 @@ classdef gabor < neurostim.stimulus
             % experiment.
             glUseProgram(o.shader);
             glUniform2f(glGetUniformLocation(o.shader , 'size'), o.width, o.height);
-            colorModes = {'RGB','XYL','LUM'}; % 1,2,3
+            colorModes = {'RGB','XYL','LUM','LINLUT'}; % 1,2,3,4
             colorMode = find(ismember(o.cic.screen.colorMode,colorModes));
             if isempty(colorMode)
                 error(['Gabor does not know how to deal with colormode ' o.cic.screen.colorMode]);


### PR DESCRIPTION
Trivial change to allow the gabor stimulus (namely the fragment shader) to work when using the LINLUT color mode. This should be completely benign for anyone *not* using LINLUT.