### PR TITLE
Bug fix for rsvp logging (breaking change)

### DIFF
--- a/+neurostim/stimulus.m
+++ b/+neurostim/stimulus.m
@@ -154,7 +154,7 @@ classdef stimulus < neurostim.plugin
             s.addProperty('rx',0,'validate',@isnumeric);
             s.addProperty('ry',0,'validate',@isnumeric);
             s.addProperty('rz',1,'validate',@isnumeric);
-            s.addProperty('rsvpIsi',false,'validate',@islogical); % Logs onset (1) and offset (0) of the RSVP "ISI" . But only if log is set to true in addRSVP.
+            s.addProperty('rsvpIsi',-1,'validate',@isnumeric); % Logs onset (1) and offset (0) of the RSVP "ISI" . But only if log is set to true in addRSVP.
             s.addProperty('disabled',false);            
             
             
@@ -277,16 +277,17 @@ classdef stimulus < neurostim.plugin
                 for sp=1:size(specs,1)
                     s.(specs{sp,2}) = specs{sp,3};
                 end
-                localizeParms(s,true);  % Update those loc parameters that change within a trial
+                 localizeParms(s,true);  % Update those loc parameters that change within a trial
             end
             
             %Blank now if it's time to do so.
-            s.flags.on = itemFrame < durationInFrames;  % Blank during rsvp isi  (< because itemFrame is base-0)
+            isOn = itemFrame < durationInFrames;
+            s.flags.on = isOn;  % Blank during rsvp isi 
             if s.rsvp.log
-                if itemFrame == 0
-                    s.rsvpIsi = false;
-                elseif itemFrame==startIsiFrame
-                    s.rsvpIsi = true;
+                if isOn
+                    s.rsvpIsi = 0;
+                else
+                    s.rsvpIsi = 1;
                 end
             end
         end


### PR DESCRIPTION
Fixes multiple bugs with the logging of rsvp stimulus onsets, i.e. addRSVP(...,'log',true)

1. a fatal error because `startIsiFrame` does not exist (a relic of some previous version of this code)
2. with that fixed, `rsvpISI` value was being logged every frame because `neurostim.parameter` checks for a value change only for numeric and string types, not for logical. I have fixed this logical logging problem in a separate pull request because I am not sure whether perhaps it was intentional that logicals would always be logged. Fixed here in a different way by making rsvpISI an integer, initialised with -1 and then values of 0 and 1.
3. Related to above, the original logical value was initialised to `false`, so the onset of the first rsvp frame was not logged. This was probably intentional because it is already logged as `startTime`, but maybe there is value in being able to use rsvpISI alone to get all the on and off times? if you disagree, initialising rsvpIsi to 0 should restore the previous behaviour. Happy to do that if it is preferred.

>**This is a potentially breaking change for analysis code that uses `rsvpISI` (because values are now 0 and 1 rather than false and true), but given there has been a fatal bug since 2021, I am guessing not many people have used this in their experiment or analysis.**