### PR TITLE
Bug fix to log logicals only on value change

### DIFF
--- a/+neurostim/parameter.m
+++ b/+neurostim/parameter.m
@@ -174,7 +174,8 @@ classdef parameter < handle & matlab.mixin.Copyable
             % Check if the value changed and log only the changes.
             % (at some point this seemed to be slower than just logging everything.
             % but tests on July 1st 2017 showed that this was (no longer) correct.
-            if  (isnumeric(v) && numel(v)==numel(o.value) && isnumeric(o.value) && isequaln(v(:),o.value(:))) || (ischar(v) && ischar(o.value) && strcmp(v,o.value)) || (islogical(v) && islogical(o.value) && v==o.value)
+            if  ((isnumeric(v) || islogical(v)) && numel(v)==numel(o.value) && (isnumeric(o.value) || islogical(o.value)) && isequaln(v(:),o.value(:))) || ...
+                    (ischar(v) && ischar(o.value) && strcmp(v,o.value))
                 % No change, no logging.
                 return;
             end

--- a/+neurostim/parameter.m
+++ b/+neurostim/parameter.m
@@ -174,7 +174,7 @@ classdef parameter < handle & matlab.mixin.Copyable
             % Check if the value changed and log only the changes.
             % (at some point this seemed to be slower than just logging everything.
             % but tests on July 1st 2017 showed that this was (no longer) correct.
-            if  (isnumeric(v) && numel(v)==numel(o.value) && isnumeric(o.value) && isequaln(v(:),o.value(:))) || (ischar(v) && ischar(o.value) && strcmp(v,o.value))
+            if  (isnumeric(v) && numel(v)==numel(o.value) && isnumeric(o.value) && isequaln(v(:),o.value(:))) || (ischar(v) && ischar(o.value) && strcmp(v,o.value)) || (islogical(v) && islogical(o.value) && v==o.value)
                 % No change, no logging.
                 return;
             end


### PR DESCRIPTION
Bug: `neurostim.parameter` checks for a value change only for numeric and string types, not for logical. So logical values are logged every time they are set, regardless. Is this intended behaviour?

> this is a potentially breaking change with wide-reach, because it changes something fundamental related to what is logged.