### PR TITLE
bug-fix: missing support for adaptive in rsvp

### DIFF
--- a/+neurostim/+plugins/adaptive.m
+++ b/+neurostim/+plugins/adaptive.m
@@ -236,9 +236,12 @@ classdef (Abstract) adaptive < neurostim.plugin
             end
         end 
         
-        function v = updateValue(o)
-
-            if ~isempty(o.lastOutcome)
+        function v = updateValue(o, force)
+            if nargin<2
+                force = false;
+            end
+            
+            if ~isempty(o.lastOutcome) || force
                 % Allow the derived class to update (based on lastValue and lastOutcome)
                 update(o); 
                 o.lastOutcome = [];

--- a/+neurostim/stimulus.m
+++ b/+neurostim/stimulus.m
@@ -275,8 +275,13 @@ classdef stimulus < neurostim.plugin
                 % Get current specs and apply
                 specs = s.rsvp.design.specs;
                 for sp=1:size(specs,1)
-                    s.(specs{sp,2}) = specs{sp,3};
-                end
+                    if isa(specs{sp,3},'neurostim.plugins.adaptive')
+                        value = updateValue(specs{sp,3}, true);
+                    else
+                        value = specs{sp,3};
+                    end
+                    s.(specs{sp,2}) = value;
+                end                
                 localizeParms(s,true);  % Update those loc parameters that change within a trial
             end
             


### PR DESCRIPTION
RSVP is implemented as "mini-trials" using a design object. But, the logic for updating params from the design spec left out the logic to support adaptive parameters like jitter.

Here's a minimal example that previously did not call the `updateOrientation()` with each rsvp frame but does in this PR.

```
function sog
%% 
% Stream of Gratings Example
% 
% Shows how a single stimulus ( a grating in this case) can be shown as a 
% rapid visual stream (RSVP) with one or more of its properties changing within a
% trial. 
%
% The experiment starts with a red dot, click with a mouse to fixate, then
% the stream of gratings will show.
% 
% BK - Feb 2016


%% Prerequisites. 
import neurostim.*


%% Setup CIC and the stimuli.
c = myRig;         % Create Command and Intelligence Center...
c.trialDuration = 5000;
c.screen.color.background = [0.5 0.5 0.5]; 

% Create a Gabor stimulus to adadot. 
g=stimuli.gabor(c,'grating');           
g.color             = [0.5 0.5 0.5];
g.contrast          = 0.25;
g.Y                 = 0; 
g.X                 = 0;
g.sigma             = 3;                       
g.phaseSpeed        = 0;
g.orientation       = 15;
g.mask              ='CIRCLE';
g.frequency         = 3;
g.on                =  1000; % Start showing 250 ms after the subject starts fixating (See 'fixation' object below).

% We want to show a rapid stream of gratings. Use the factorial class to
% define these "conditions" in the stream.
stream =design('ori');           % Define a factorial with one factor
%stream.fac1.grating.orientation = 0:30:359; % Assign orientations
stream.fac1.grating.Y = 0;
stream.randomization = 'RANDOMWITHOUTREPLACEMENT'; % Randomize
stream.conditions(:).grating.orientation = plugins.jitter(c,{g},'distribution',@updateOrientation);
g.addRSVP(stream,'duration',6*1000/c.screen.frameRate,'isi',3*1000/c.screen.frameRate); % Tell the stimulus that it should run this stream (in every trial). 5 frames on 2 frames off.


%% Define conditions and blocks
% We will show the stream of gratings with different contrasts in each
% trial.
% d=design('contrast');           % Define a factorial with one factor
% d.fac1.grating.contrast = 0.1:0.2:1; % From 10 to 100% contrast
% d.randomization = 'RANDOMWITHOUTREPLACEMENT';

% Or (if the stream already varies contrast and orientation, we vary
% nothing across trials).
d=design('dummy');           % Define a factorial with one factor
% Nothing to vary here but we need at least one condition
d.conditions(1).grating.X = 0; % Dummy
blck=block('block',d);                  % Define a block based on this factorial
blck.nrRepeats  =10;                        % Each condition is repeated this many times 

%% Run the experiment   
c.cursor = 'arrow';
% Now tell CIC how we want to run these blocks 
c.run(blck);
 
function val = updateOrientation(o)
val = o.orientation+5;
```