### PR TITLE
New features: (1) log every key press, (2) generic support to log every assignment to a `neurostim.parameter`, even if value unchanged

### DIFF
--- a/+neurostim/cic.m
+++ b/+neurostim/cic.m
@@ -1378,7 +1378,7 @@ classdef cic < neurostim.plugin
             c.kbInfo.plugin{ix} = plg; % Handle to plugin to call keyboard()
             c.kbInfo.isSubject(ix) = isSubject;
             c.kbInfo.fun{ix} = fun;
-            c.kbInfo.logKeyPress{ix} = logKeyPress
+            c.kbInfo.logKeyPress{ix} = logKeyPress;
         end
 
         function removeKeyStroke(c,key)
@@ -1646,7 +1646,7 @@ classdef cic < neurostim.plugin
                         keyName = KbName(k);
                         if length(ix) >1;error(['More than one plugin (or derived class) is listening to  ' keyName '??']);end
                         if c.kbInfo.logKeyPress{ix}
-                            c.pressedKey = {GetSecs, keyName};
+                            c.pressedKey = {keyName}; %cell arrays are always logged, even if same value inside
                         end
                         if isempty(c.kbInfo.fun{ix})
                             % Use the plugin's keyboard function

--- a/+neurostim/cic.m
+++ b/+neurostim/cic.m
@@ -2173,8 +2173,8 @@ classdef cic < neurostim.plugin
             end
         end
 
-        function removeKeyStroke(c,key)
-            % removeKeyStrokes(c,key)
+        function deregisterKey(c,key)
+            % deregisterKey(c,key)
             % removes keys (cell array of strings) from cic. These keys are
             % no longer listened to.
             if ischar(key) || iscellstr(key) || isstring(key)

--- a/+neurostim/cic.m
+++ b/+neurostim/cic.m
@@ -1344,8 +1344,8 @@ classdef cic < neurostim.plugin
         %% Keyboard handling routines
         function oldKey = addKeyStroke(c,key,keyHelp,plg,isSubject,fun,force,logKeyPress)
             if c.loadedFromFile
-                % When loading fro file, PTB may not be installed and none
-                % of the "online/intractive" funcationality is relevant.
+                % When loading from file, PTB may not be installed and none
+                % of the "online/interactive" functionality is relevant.
                 oldKey = struct; % empty struct
                 return;
             end
@@ -1366,8 +1366,8 @@ classdef cic < neurostim.plugin
                     oldKey.help = c.kbInfo.help{ix};
                     oldKey.plg = c.kbInfo.plugin{ix};
                     oldKey.isSubject  = c.kbInfo.isSubject(ix);
-                    oldKey.fun  = c.kbInfo.fun{ix};
-                    oldKey.fun  = c.kbInfo.logKeyPress{ix};
+                    oldKey.fun = c.kbInfo.fun{ix};
+                    oldKey.logKeyPress = c.kbInfo.logKeyPress{ix};
                 end
             else
                 oldKey = [];
@@ -1394,11 +1394,11 @@ classdef cic < neurostim.plugin
             else
                 out = ismember(c.kbInfo.keys,key);
                 c.kbInfo.keys(out) = [];
-                c.kbInfo.help(out)  = [];
+                c.kbInfo.help(out) = [];
                 c.kbInfo.plugin(out) = [];
                 c.kbInfo.isSubject(out) = [];
-                c.kbInfo.fun(out) =[];
-                c.kbInfo.logKeyPress(out) =[];
+                c.kbInfo.fun(out) = [];
+                c.kbInfo.logKeyPress(out) = [];
             end
         end
 

--- a/+neurostim/cic.m
+++ b/+neurostim/cic.m
@@ -1643,10 +1643,11 @@ classdef cic < neurostim.plugin
                     ks = find(firstPress);
                     for k=ks
                         ix = find(c.kbInfo.keys==k);% should be only one.
-                        keyName = KbName(k)
+                        keyName = KbName(k);
                         if length(ix) >1;error(['More than one plugin (or derived class) is listening to  ' keyName '??']);end
                         if c.kbInfo.logKeyPress{ix}
-                            c.pressedKey = [GetSecs, keyName]
+                            c.pressedKey = {GetSecs, keyName};
+                        end
                         if isempty(c.kbInfo.fun{ix})
                             % Use the plugin's keyboard function
                             keyboard(c.kbInfo.plugin{ix},keyName);%,firstPress(k));

--- a/+neurostim/cic.m
+++ b/+neurostim/cic.m
@@ -440,7 +440,6 @@ classdef cic < neurostim.plugin
             c.addProperty('matlabVersion', []); %Log MATLAB version used to run this experiment - set at runtime
             c.addProperty('ptbVersion',[]); % Log PTB Version used to run this experiment - set at runtime
             c.addProperty('repoVersion',[]); % Information on the git version/hash. - set at runtime
-            c.addProperty('pressedKey',[]); % Used to log key presses
             c.feedStyle = '*[0.9294    0.6941    0.1255]'; % CIC messages in bold orange
 
 
@@ -1379,6 +1378,9 @@ classdef cic < neurostim.plugin
             c.kbInfo.isSubject(ix) = isSubject;
             c.kbInfo.fun{ix} = fun;
             c.kbInfo.logKeyPress{ix} = logKeyPress;
+            if logKeyPress
+              plg.addProperty('pressedKey',[],'logAll',true); % Used to log key presses
+            end
         end
 
         function removeKeyStroke(c,key)
@@ -1641,12 +1643,12 @@ classdef cic < neurostim.plugin
                     %                 lastPress(out) =[];
                     %                 lastRelease(out)=[];
                     ks = find(firstPress);
-                    for k=ks
+                    for k = ks
                         ix = find(c.kbInfo.keys==k);% should be only one.
                         keyName = KbName(k);
                         if length(ix) >1;error(['More than one plugin (or derived class) is listening to  ' keyName '??']);end
                         if c.kbInfo.logKeyPress{ix}
-                            c.pressedKey = {keyName}; %cell arrays are always logged, even if same value inside
+                            c.kbInfo.plugin{ix}.pressedKey = keyName;
                         end
                         if isempty(c.kbInfo.fun{ix})
                             % Use the plugin's keyboard function

--- a/+neurostim/cic.m
+++ b/+neurostim/cic.m
@@ -78,7 +78,7 @@ classdef cic < neurostim.plugin
             'subject',{[]},... % The keyboard that will handle keys for which isSubect is true (=by default stimuli)
             'experimenter',{[]},...% The keyboard that will handle keys for which isSubject is false (plugins by default)
             'pressAnyKey',{-1},... % Keyboard for start experiment, block ,etc. -1 means any
-            'logKeyPress', {logical([])},...% Should we log the key press?
+            'log', {logical([])},...% Should we log the key press?
             'activeKb',{[]});  % Indices of keyboard that have keys associated with them. Set and used internally)
 
         %% Git version tracking
@@ -1583,7 +1583,7 @@ classdef cic < neurostim.plugin
                         ix = find(c.kbInfo.keys==k);% should be only one.
                         keyName = KbName(k);
                         if length(ix) >1;error(['More than one plugin (or derived class) is listening to  ' keyName '??']);end
-                        if c.kbInfo.logKeyPress{ix}
+                        if c.kbInfo.log{ix}
                             c.kbInfo.plugin{ix}.pressedKey = keyName;
                         end
                         if isempty(c.kbInfo.fun{ix})
@@ -1632,7 +1632,9 @@ classdef cic < neurostim.plugin
                 end
             end
         end
-
+        function oldKey = addKeyStroke(c,key,keyHelp,plg,isSubject,fun,force,log)
+            c.error('STOPEXPERIMENT', "'addKeyStroke' has been deprecated. use 'addKey()'. see: neurostim.plugin.addKey'")
+        end
     end
 
     methods (Access=private)
@@ -2129,7 +2131,7 @@ classdef cic < neurostim.plugin
         % Note that addKeyStroke() and removeKeyStroke() were previously
         % public methods, moved here to make plugin.addKey() and
         % plugin.removeKey() the public methods to remove duplication
-        function oldKey = addKeyStroke(c,key,keyHelp,plg,isSubject,fun,force,logKeyPress)
+        function oldKey = registerKey(c,key,keyHelp,plg,isSubject,fun,force,log)
             if c.loadedFromFile
                 % When loading from file, PTB may not be installed and none
                 % of the "online/interactive" functionality is relevant.
@@ -2154,7 +2156,7 @@ classdef cic < neurostim.plugin
                     oldKey.plg = c.kbInfo.plugin{ix};
                     oldKey.isSubject  = c.kbInfo.isSubject(ix);
                     oldKey.fun = c.kbInfo.fun{ix};
-                    oldKey.logKeyPress = c.kbInfo.logKeyPress{ix};
+                    oldKey.log = c.kbInfo.log{ix};
                 end
             else
                 oldKey = [];
@@ -2165,8 +2167,8 @@ classdef cic < neurostim.plugin
             c.kbInfo.plugin{ix} = plg; % Handle to plugin to call keyboard()
             c.kbInfo.isSubject(ix) = isSubject;
             c.kbInfo.fun{ix} = fun;
-            c.kbInfo.logKeyPress{ix} = logKeyPress;
-            if logKeyPress
+            c.kbInfo.log{ix} = log;
+            if log
               plg.addProperty('pressedKey',[],'logMode',neurostim.parameter.LOGALL); % Used to log key presses
             end
         end
@@ -2188,7 +2190,7 @@ classdef cic < neurostim.plugin
                 c.kbInfo.plugin(out) = [];
                 c.kbInfo.isSubject(out) = [];
                 c.kbInfo.fun(out) = [];
-                c.kbInfo.logKeyPress(out) = [];
+                c.kbInfo.log(out) = [];
             end
         end
         

--- a/+neurostim/cic.m
+++ b/+neurostim/cic.m
@@ -1379,7 +1379,7 @@ classdef cic < neurostim.plugin
             c.kbInfo.fun{ix} = fun;
             c.kbInfo.logKeyPress{ix} = logKeyPress;
             if logKeyPress
-              plg.addProperty('pressedKey',[],'logAll',true); % Used to log key presses
+              plg.addProperty('pressedKey',[],'logMode',neurostim.parameter.LOGALL); % Used to log key presses
             end
         end
 

--- a/+neurostim/cic.m
+++ b/+neurostim/cic.m
@@ -880,7 +880,7 @@ classdef cic < neurostim.plugin
 
         function error(c,command,msg)
             switch (command)
-                case 'STOPEXPERIMENT'
+                case 'STOPEXPERIMENT' & c.stage ~= neurostim.cic.SETUP
                     c.writeToFeed(msg,'style','red');
                     c.flags.experiment = false;
                 case 'CONTINUE'
@@ -1633,7 +1633,7 @@ classdef cic < neurostim.plugin
             end
         end
         function oldKey = addKeyStroke(c,key,keyHelp,plg,isSubject,fun,force,log)
-            c.error('STOPEXPERIMENT', "'addKeyStroke' has been deprecated. use 'addKey()'. see: neurostim.plugin.addKey'")
+            c.error('STOPEXPERIMENT', '''"addKeyStroke" has been deprecated. use "addKey()". see: neurostim.plugin.addKey''')
         end
     end
 

--- a/+neurostim/cic.m
+++ b/+neurostim/cic.m
@@ -78,7 +78,7 @@ classdef cic < neurostim.plugin
             'subject',{[]},... % The keyboard that will handle keys for which isSubect is true (=by default stimuli)
             'experimenter',{[]},...% The keyboard that will handle keys for which isSubject is false (plugins by default)
             'pressAnyKey',{-1},... % Keyboard for start experiment, block ,etc. -1 means any
-            'logKeyPress', {logical([])},...% Should we log the key press (as [GetSecs, key])?
+            'logKeyPress', {logical([])},...% Should we log the key press?
             'activeKb',{[]});  % Indices of keyboard that have keys associated with them. Set and used internally)
 
         %% Git version tracking
@@ -1340,70 +1340,6 @@ classdef cic < neurostim.plugin
             %Screen('CloseAll');
         end
 
-        %% Keyboard handling routines
-        function oldKey = addKeyStroke(c,key,keyHelp,plg,isSubject,fun,force,logKeyPress)
-            if c.loadedFromFile
-                % When loading from file, PTB may not be installed and none
-                % of the "online/interactive" functionality is relevant.
-                oldKey = struct; % empty struct
-                return;
-            end
-            if ischar(key)
-                key = KbName(key);
-            end
-            if ~isnumeric(key) || key <1 || key>256
-                error('Please use KbName to add keys')
-            end
-            ix = ismember(c.kbInfo.keys,key);
-            if  any(ix)
-                if ~force
-                    error(['The ' key ' key is in use. You cannot add it again...']);
-                else
-                    % Forcing a replacement - return old key so that the
-                    % user can restore later.
-                    oldKey.key = c.kbInfo.keys(ix);
-                    oldKey.help = c.kbInfo.help{ix};
-                    oldKey.plg = c.kbInfo.plugin{ix};
-                    oldKey.isSubject  = c.kbInfo.isSubject(ix);
-                    oldKey.fun = c.kbInfo.fun{ix};
-                    oldKey.logKeyPress = c.kbInfo.logKeyPress{ix};
-                end
-            else
-                oldKey = [];
-                ix = numel(c.kbInfo.keys)+1; % Add a new one
-            end
-            c.kbInfo.keys(ix)  = key;
-            c.kbInfo.help{ix} = keyHelp;
-            c.kbInfo.plugin{ix} = plg; % Handle to plugin to call keyboard()
-            c.kbInfo.isSubject(ix) = isSubject;
-            c.kbInfo.fun{ix} = fun;
-            c.kbInfo.logKeyPress{ix} = logKeyPress;
-            if logKeyPress
-              plg.addProperty('pressedKey',[],'logMode',neurostim.parameter.LOGALL); % Used to log key presses
-            end
-        end
-
-        function removeKeyStroke(c,key)
-            % removeKeyStrokes(c,key)
-            % removes keys (cell array of strings) from cic. These keys are
-            % no longer listened to.
-            if ischar(key) || iscellstr(key) || isstring(key)
-                key = KbName(key);
-            end
-            ix = ismember(key,c.kbInfo.keys);
-            if ~any(ix)
-                warning(['The ' key(~ix) ' key is not in use. You cannot remove it...??']);
-            else
-                out = ismember(c.kbInfo.keys,key);
-                c.kbInfo.keys(out) = [];
-                c.kbInfo.help(out) = [];
-                c.kbInfo.plugin(out) = [];
-                c.kbInfo.isSubject(out) = [];
-                c.kbInfo.fun(out) = [];
-                c.kbInfo.logKeyPress(out) = [];
-            end
-        end
-
         function [a,b] = pixel2Physical(c,x,y)
             % converts from pixel dimensions to physical ones.
             a = (x./c.screen.xpixels-0.5)*c.screen.width;
@@ -2189,7 +2125,73 @@ classdef cic < neurostim.plugin
     end
 
     methods (Access=?neurostim.plugin)
+        %% Keyboard handling routines
+        % Note that addKeyStroke() and removeKeyStroke() were previously
+        % public methods, moved here to make plugin.addKey() and
+        % plugin.removeKey() the public methods to remove duplication
+        function oldKey = addKeyStroke(c,key,keyHelp,plg,isSubject,fun,force,logKeyPress)
+            if c.loadedFromFile
+                % When loading from file, PTB may not be installed and none
+                % of the "online/interactive" functionality is relevant.
+                oldKey = struct; % empty struct
+                return;
+            end
+            if ischar(key)
+                key = KbName(key);
+            end
+            if ~isnumeric(key) || key <1 || key>256
+                error('Please use KbName to add keys')
+            end
+            ix = ismember(c.kbInfo.keys,key);
+            if  any(ix)
+                if ~force
+                    error(['The ' key ' key is in use. You cannot add it again...']);
+                else
+                    % Forcing a replacement - return old key so that the
+                    % user can restore later.
+                    oldKey.key = c.kbInfo.keys(ix);
+                    oldKey.help = c.kbInfo.help{ix};
+                    oldKey.plg = c.kbInfo.plugin{ix};
+                    oldKey.isSubject  = c.kbInfo.isSubject(ix);
+                    oldKey.fun = c.kbInfo.fun{ix};
+                    oldKey.logKeyPress = c.kbInfo.logKeyPress{ix};
+                end
+            else
+                oldKey = [];
+                ix = numel(c.kbInfo.keys)+1; % Add a new one
+            end
+            c.kbInfo.keys(ix)  = key;
+            c.kbInfo.help{ix} = keyHelp;
+            c.kbInfo.plugin{ix} = plg; % Handle to plugin to call keyboard()
+            c.kbInfo.isSubject(ix) = isSubject;
+            c.kbInfo.fun{ix} = fun;
+            c.kbInfo.logKeyPress{ix} = logKeyPress;
+            if logKeyPress
+              plg.addProperty('pressedKey',[],'logMode',neurostim.parameter.LOGALL); % Used to log key presses
+            end
+        end
 
+        function removeKeyStroke(c,key)
+            % removeKeyStrokes(c,key)
+            % removes keys (cell array of strings) from cic. These keys are
+            % no longer listened to.
+            if ischar(key) || iscellstr(key) || isstring(key)
+                key = KbName(key);
+            end
+            ix = ismember(key,c.kbInfo.keys);
+            if ~any(ix)
+                warning(['The ' key(~ix) ' key is not in use. You cannot remove it...??']);
+            else
+                out = ismember(c.kbInfo.keys,key);
+                c.kbInfo.keys(out) = [];
+                c.kbInfo.help(out) = [];
+                c.kbInfo.plugin(out) = [];
+                c.kbInfo.isSubject(out) = [];
+                c.kbInfo.fun(out) = [];
+                c.kbInfo.logKeyPress(out) = [];
+            end
+        end
+        
         function rng = requestRNGstream(c,nStreams,makeItAGPUrng)
             %Plugins can request their own RNG stream. We created N (3) RNG
             %streams on construction of CIC, so allocate one of those now.

--- a/+neurostim/parameter.m
+++ b/+neurostim/parameter.m
@@ -74,7 +74,7 @@ classdef parameter < handle & matlab.mixin.Copyable
         time;                       % Time at which previous values were set
         cntr=0;                     % Counter to store where in the log we are.
         capacity=0;                 % Capacity to store in log
-        logMode;                    % one of LOGNOTHING, LOGCHANGES or LOGALLVALS
+        logMode;                    % One of LOGNOTHING, LOGCHANGES or LOGALLVALS
         fun =[];                    % Function to allow across parameter dependencies
         funPrms;
         funStr = '';                % The neurostim function string
@@ -746,12 +746,22 @@ classdef parameter < handle & matlab.mixin.Copyable
         end
         
         function o = loadobj(o)
-            %Parameters that were initialised to [] and remained empty were not logged properly
-            %on construction in old files. Fix it here
+            % Parameters that were initialised to [] and remained empty were
+            % not logged properly on construction in old files. Fix it here.
             if ~o.cntr
                 o.cntr = 1;
                 o.log{1} = [];
                 o.time = -Inf;
+            end
+            
+            % Not all logging modes were supported in old files. Fix it here.
+            if isfield(o,'noLog') && ~isfield(o,'logMode')
+              logMode = neurostim.parameter.LOGCHANGES;
+              if o.noLog
+                logMode = neurostim.parameter.LOGNOTHING;
+              end
+              o.logMode = logMode;
+              o = rmfield(o,'noLog')
             end
             
             o = neurostim.parameter(o);

--- a/+neurostim/plugin.m
+++ b/+neurostim/plugin.m
@@ -55,8 +55,8 @@ classdef plugin  < dynamicprops & matlab.mixin.Copyable & matlab.mixin.Heterogen
         end
         
         
-        function oldKey = addKey(o,key,keyHelp,isSubject,fun,force,plg,logKeyPress)
-            %  addKey(o,key,keyHelp,isSubject,fun)
+        function oldKey = addKey(o,key,keyHelp,isSubject,fun,force,plg,log)
+            %  addKey(o,key,keyHelp,isSubject,fun,force,plg,log)
             % Runs a function in response to a specific key press.
             % key - a single key (string)
             % keyHelp -  a string that explains what this key does
@@ -69,11 +69,13 @@ classdef plugin  < dynamicprops & matlab.mixin.Copyable & matlab.mixin.Heterogen
             % force - set to true to force adding this key (and thereby
             % taking it away from anihter plugin). This only makes sense if
             % you restore it soon after, using the returned keyInfo.
-            % logKeyPress - set to true to log every key press
+            % plg - the plugin that should react to the key (defaults to
+            % self)
+            % log - set to true to log every key press
 
             nin =nargin;
             if nin < 8
-                logKeyPress = false;
+                log = false;
                 if nin <7
                     plg = o;
                     if nin <6
@@ -84,13 +86,16 @@ classdef plugin  < dynamicprops & matlab.mixin.Copyable & matlab.mixin.Heterogen
                                 isSubject = isa(o,'neurostim.stimulus') || isa(o,'neurostim.behavior');
                                 if nin <3
                                     keyHelp = '?';
+                                    if nin < 2
+                                        o.cic.error('STOPEXPERIMENT', "Must provide a key; e.g. 's'")
+                                    end
                                 end
                             end
                         end
                     end
                 end
             end
-            oldKey = addKeyStroke(o.cic,key,keyHelp,plg,isSubject,fun,force,logKeyPress);
+            oldKey = registerKey(o.cic,key,keyHelp,plg,isSubject,fun,force,log);
         end
         
         function logKey(o, key, isSubject)
@@ -101,8 +106,8 @@ classdef plugin  < dynamicprops & matlab.mixin.Copyable & matlab.mixin.Heterogen
             if nargin < 3
                 isSubject = false;
             end
-            do_nothing = @(o,key) [];
-            addKey(o,key,"",isSubject,do_nothing,false,o,true)
+
+            addKey(o,key,"",isSubject,[],false,o,true)
         end
         
         function removeKey(o,key)

--- a/+neurostim/plugin.m
+++ b/+neurostim/plugin.m
@@ -105,6 +105,11 @@ classdef plugin  < dynamicprops & matlab.mixin.Copyable & matlab.mixin.Heterogen
             addKey(o,key,"",isSubject,do_nothing,false,o,true)
         end
         
+        function removeKey(o,key)
+            % Users add and remove keys through plugins, not cic directly.
+            o.cic.removeKeyStroke(key)
+        end
+        
         % Convenience wrapper; just passed to CIC
         function endTrial(o)
             % Move to the next trial

--- a/+neurostim/plugin.m
+++ b/+neurostim/plugin.m
@@ -55,7 +55,7 @@ classdef plugin  < dynamicprops & matlab.mixin.Copyable & matlab.mixin.Heterogen
         end
         
         
-        function oldKey = addKey(o,key,keyHelp,isSubject,fun,force,plg)
+        function oldKey = addKey(o,key,keyHelp,isSubject,fun,force,plg,logKeyPress)
             %  addKey(o,key,keyHelp,isSubject,fun)
             % Runs a function in response to a specific key press.
             % key - a single key (string)
@@ -69,25 +69,40 @@ classdef plugin  < dynamicprops & matlab.mixin.Copyable & matlab.mixin.Heterogen
             % force - set to true to force adding this key (and thereby
             % taking it away from anihter plugin). This only makes sense if
             % you restore it soon after, using the returned keyInfo.
+            % logKeyPress - set to true to log every key press
+
             nin =nargin;
-            if nin <7
-                plg = o;
-                if nin <6
-                    force =false;
-                    if nin<5
-                        fun =[];
-                        if nin < 4
-                            isSubject = isa(o,'neurostim.stimulus') || isa(o,'neurostim.behavior');
-                            if nin <3
-                                keyHelp = '?';
+            if nin < 8
+                logKeyPress = false
+                if nin <7
+                    plg = o;
+                    if nin <6
+                        force =false;
+                        if nin<5
+                            fun =[];
+                            if nin < 4
+                                isSubject = isa(o,'neurostim.stimulus') || isa(o,'neurostim.behavior');
+                                if nin <3
+                                    keyHelp = '?';
+                                end
                             end
                         end
                     end
                 end
-            end
-            oldKey = addKeyStroke(o.cic,key,keyHelp,plg,isSubject,fun,force);
+            oldKey = addKeyStroke(o.cic,key,keyHelp,plg,isSubject,fun,force,logKeyPress);
         end
         
+        function logKey(o, key, isSubject)
+            % Public convenience function to turn on logging for a particular key without any callback
+            % key - a single key (string)
+            % isSubject - bool to indicate whether this is a key press on the subject side (true) or experimenter (false) 
+
+            if nin < 3
+                isSubject = false
+                
+            do_nothing = @() []
+            o.addKey(o,key,"",isSubject,do_nothing,false,o,true)
+
         % Convenience wrapper; just passed to CIC
         function endTrial(o)
             % Move to the next trial

--- a/+neurostim/plugin.m
+++ b/+neurostim/plugin.m
@@ -146,7 +146,7 @@ classdef plugin  < dynamicprops & matlab.mixin.Copyable & matlab.mixin.Heterogen
             p.addParameter('SetAccess','public');
             p.addParameter('GetAccess','public');
             p.addParameter('noLog',false,@islogical);
-            p.addParameter('logAll',false,@islogical);
+            p.addParameter('logMode',neurostim.parameter.LOGCHANGES,@isnumeric);
             p.addParameter('sticky',false,@islogical);
             p.addParameter('changesInTrial',false,@islogical); % Indicate that this is a variable that gets new values assiged inthe beforeFrame/afterFrame user code.
             p.parse(varargin{:});

--- a/+neurostim/plugin.m
+++ b/+neurostim/plugin.m
@@ -73,7 +73,7 @@ classdef plugin  < dynamicprops & matlab.mixin.Copyable & matlab.mixin.Heterogen
 
             nin =nargin;
             if nin < 8
-                logKeyPress = false
+                logKeyPress = false;
                 if nin <7
                     plg = o;
                     if nin <6
@@ -89,6 +89,7 @@ classdef plugin  < dynamicprops & matlab.mixin.Copyable & matlab.mixin.Heterogen
                         end
                     end
                 end
+            end
             oldKey = addKeyStroke(o.cic,key,keyHelp,plg,isSubject,fun,force,logKeyPress);
         end
         
@@ -97,12 +98,13 @@ classdef plugin  < dynamicprops & matlab.mixin.Copyable & matlab.mixin.Heterogen
             % key - a single key (string)
             % isSubject - bool to indicate whether this is a key press on the subject side (true) or experimenter (false) 
 
-            if nin < 3
-                isSubject = false
-                
-            do_nothing = @() []
-            o.addKey(o,key,"",isSubject,do_nothing,false,o,true)
-
+            if nargin < 3
+                isSubject = false;
+            end
+            do_nothing = @(o,key) [];
+            addKey(o,key,"",isSubject,do_nothing,false,o,true)
+        end
+        
         % Convenience wrapper; just passed to CIC
         function endTrial(o)
             % Move to the next trial

--- a/+neurostim/plugin.m
+++ b/+neurostim/plugin.m
@@ -99,15 +99,15 @@ classdef plugin  < dynamicprops & matlab.mixin.Copyable & matlab.mixin.Heterogen
         end
         
         function logKey(o, key, isSubject)
-            % Public convenience function to turn on logging for a particular key without any callback
+            % Public convenience function to turn on logging for a key without any callback
             % key - a single key (string)
             % isSubject - bool to indicate whether this is a key press on the subject side (true) or experimenter (false) 
 
             if nargin < 3
-                isSubject = false;
+                isSubject = isa(o,'neurostim.stimulus') || isa(o,'neurostim.behavior');
             end
-
-            addKey(o,key,"",isSubject,[],false,o,true)
+            do_nothing = @(o,key) [];
+            addKey(o,key,"",isSubject,do_nothing,false,o,true)
         end
         
         function removeKey(o,key)

--- a/+neurostim/plugin.m
+++ b/+neurostim/plugin.m
@@ -146,6 +146,7 @@ classdef plugin  < dynamicprops & matlab.mixin.Copyable & matlab.mixin.Heterogen
             p.addParameter('SetAccess','public');
             p.addParameter('GetAccess','public');
             p.addParameter('noLog',false,@islogical);
+            p.addParameter('logAll',false,@islogical);
             p.addParameter('sticky',false,@islogical);
             p.addParameter('changesInTrial',false,@islogical); % Indicate that this is a variable that gets new values assiged inthe beforeFrame/afterFrame user code.
             p.parse(varargin{:});

--- a/+neurostim/plugin.m
+++ b/+neurostim/plugin.m
@@ -112,7 +112,7 @@ classdef plugin  < dynamicprops & matlab.mixin.Copyable & matlab.mixin.Heterogen
         
         function removeKey(o,key)
             % Users add and remove keys through plugins, not cic directly.
-            o.cic.removeKeyStroke(key)
+            o.cic.deregisterKey(key)
         end
         
         % Convenience wrapper; just passed to CIC


### PR DESCRIPTION
Adds support to log an event every time a key is pressed.

`o.logKey('a')`.

Problem with current implementation: it's logging in cic rather than in the plugin that made the request. To be fixed.