### PR TITLE
bug-fix: restore printing of ns data file location at end of experiment

### DIFF
--- a/+neurostim/messenger.m
+++ b/+neurostim/messenger.m
@@ -104,6 +104,7 @@ classdef messenger < handle
                 data.command = 'CLOSE';
                 sendCommand(o,data);
             end
+            printCache(o)
         end
         
         function disp(o)


### PR DESCRIPTION
ns no longer prints the name and location of the experiment data file at the end of the session. A user has no idea data has been saved, or where to look for it! confusing for new user, for sure. It used to be shown but I think disappeared with the arrival of the messenger approach. This restores the original output, as below, by ensuring messenger cache is printed before closing.
```
TR: 3 (T: 1467 ): cic - Data for trials 1:3 saved to C:\Users\USER\AppData\Local\Temp\2024\09\08\dfdf.test.144248.mat 
TR: 3 (T: 1467 ): cic - Saving the file took 0.045817 s 
TR: 3 (T: 1467 ): cic - Screen Message: This is the end...
 
TR: 3 (T: 1467 ): cic - Data for trials 1:3 saved to C:\Users\USER\AppData\Local\Temp\2024\09\08\dfdf.test.144248.mat 
```