### PR TITLE
bug-fix stimuli.arc

### DIFF
--- a/+neurostim/+stimuli/arc.m
+++ b/+neurostim/+stimuli/arc.m
@@ -29,7 +29,7 @@ classdef arc < neurostim.stimulus
             if o.filled
                 Screen('FillArc',o.window, o.color,rect,o.startAngle, o.arcAngle);
             else
-                Screen('FrameArc',o.window, o.color,rect,o.startAngle, o.arcAngle);
+                Screen('FrameArc',o.window, o.color,rect,o.startAngle, o.arcAngle, o.linewidth, o.linewidth);
             end
             
         end


### PR DESCRIPTION
In drawing a frameArc, linewidth property was left unused. This bug has been simply fixed by supplying linewidth as 7th&8th inputs to Screen().