### PR TITLE
fix eyelink.valid handling when .loc_useRawData == true

### DIFF
--- a/+neurostim/+plugins/eyelink.m
+++ b/+neurostim/+plugins/eyelink.m
@@ -404,7 +404,7 @@ classdef eyelink < neurostim.plugins.eyetracker
                       % get gaze position (in display pixels)
                       [o.x,o.y] = o.raw2ns(sample.gx(eyeNr+1),sample.gy(eyeNr+1)); % eyeNr+1, since we're indexing a MATLAB array
                       o.valid  = any(sample.gx(eyeNr+1)~=o.el.MISSING_DATA); % Blink or other missing data.
-                  end
+                    end
                                         
                     o.pupilSize = sample.pa(eyeNr+1);
                 end

--- a/+neurostim/+plugins/eyelink.m
+++ b/+neurostim/+plugins/eyelink.m
@@ -399,13 +399,14 @@ classdef eyelink < neurostim.plugins.eyetracker
                     if o.loc_useRawData
                       % get raw camera (x,y) of pupil center and apply o.clbMatrix (see @eyetracker)
                       [o.x,o.y] = o.raw2ns(sample.px(eyeNr+1),sample.py(eyeNr+1)); % eyeNr+1, since we're indexing a MATLAB array
+                      o.valid  = any(sample.px(eyeNr+1)~=o.el.MISSING_DATA); % Blink or other missing data.
                     else
                       % get gaze position (in display pixels)
                       [o.x,o.y] = o.raw2ns(sample.gx(eyeNr+1),sample.gy(eyeNr+1)); % eyeNr+1, since we're indexing a MATLAB array
-                    end
+                      o.valid  = any(sample.gx(eyeNr+1)~=o.el.MISSING_DATA); % Blink or other missing data.
+                  end
                                         
                     o.pupilSize = sample.pa(eyeNr+1);
-                    o.valid  = any(sample.gx(eyeNr+1)~=o.el.MISSING_DATA); % Blink or other missing data.
                 end
             end
             if o.getEvents


### PR DESCRIPTION
When eyelink plugin is operated with `.loc_useRawData` = false, `.valid` stays always false even during blinking. This causes unintended behaviour of `eyeMovement.isInWindow`, always returning false.

The unintended behavior of `.valid` stems from its definition:
[`o.valid  = any(sample.gx(eyeNr+1)~=o.el.MISSING_DATA);
`](https://github.com/klabhub/neurostim/blob/c6093a39641e0763131c8590ade0d021e445663d/%2Bneurostim/%2Bplugins/eyelink.m#L408C21-L408C75)
When operated with `.loc_useRawData` = true, `gx` always returns `el.MISSING_DATA (=-32768)`. Thus .valid stays false.

Instead, `px` returns sensible values during successful eye tracking and returns el.MISSING_DATA (=-32768) only during unsuccessful eye tracking such us during blinking.

Hence, a simple fix to this problem is to define `.valid` by `px` as:
```
if o.loc_useRawData
o.valid  = any(sample.px(eyeNr+1)~=o.el.MISSING_DATA);
end
```

